### PR TITLE
fix: package name and go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
-module mods
+module github.com/charmbracelet/mods
 
-go 1.20
+go 1.18
 
 require (
 	github.com/charmbracelet/log v0.2.1


### PR DESCRIPTION
* Modifies the package name to use `github.com/charmbracelet`
* Downgrades to using Go 1.18 to make it easier for package managers to package `mods`