### PR TITLE
feat: customize text shown in generating animation

### DIFF
--- a/config.go
+++ b/config.go
@@ -15,11 +15,12 @@ type config struct {
 	Temperature       float32 `env:"TEMP" envDefault:"1.0"`
 	TopP              float32 `env:"TOPP" envDefault:"1.0"`
 	ShowHelp          bool
-	NoLimit           bool `env:"NO_LIMIT"`
-	IncludePromptArgs bool `env:"INCLUDE_PROMPT_ARGS"`
-	IncludePrompt     int  `env:"INCLUDE_PROMPT"`
-	MaxRetries        int  `env:"MAX_RETRIES" envDefault:"5"`
-	Fanciness         uint `env:"FANCINESS" envDefault:"10"`
+	NoLimit           bool   `env:"NO_LIMIT"`
+	IncludePromptArgs bool   `env:"INCLUDE_PROMPT_ARGS"`
+	IncludePrompt     int    `env:"INCLUDE_PROMPT"`
+	MaxRetries        int    `env:"MAX_RETRIES" envDefault:"5"`
+	Fanciness         uint   `env:"FANCINESS" envDefault:"10"`
+	StatusText        string `env:"STATUS_TEXT" envDefault:"Generating"`
 	Prefix            string
 	Version           bool
 }
@@ -45,6 +46,7 @@ func newConfig() (config, error) {
 	flag.Float32Var(&c.Temperature, "temp", c.Temperature, "Temperature (randomness) of results, from 0.0 to 2.0.")
 	flag.Float32Var(&c.TopP, "topp", c.TopP, "TopP, an alternative to temperature that narrows response, from 0.0 to 1.0.")
 	flag.UintVar(&c.Fanciness, "fanciness", c.Fanciness, "Number of cycling characters in the 'generating' animation.") //nolint:gomnd
+	flag.StringVar(&c.StatusText, "status-text", c.StatusText, "Text to show while generating.")
 	flag.Lookup("prompt").NoOptDefVal = "-1"
 	flag.Parse()
 	c.Prefix = strings.Join(flag.Args(), " ")

--- a/cyclingchars.go
+++ b/cyclingchars.go
@@ -12,9 +12,8 @@ import (
 )
 
 const (
-	cyclingCharsLabel = "Generating"
-	charCyclingFPS    = time.Second / 22
-	maxCyclingChars   = 120
+	charCyclingFPS  = time.Second / 22
+	maxCyclingChars = 120
 )
 
 var (
@@ -77,7 +76,7 @@ type cyclingChars struct {
 	styles          styles
 }
 
-func newCyclingChars(initialCharsSize uint, r *lipgloss.Renderer, s styles) cyclingChars {
+func newCyclingChars(initialCharsSize uint, label string, r *lipgloss.Renderer, s styles) cyclingChars {
 	n := int(initialCharsSize)
 	if n > maxCyclingChars {
 		n = maxCyclingChars
@@ -90,7 +89,7 @@ func newCyclingChars(initialCharsSize uint, r *lipgloss.Renderer, s styles) cycl
 
 	c := cyclingChars{
 		start:    time.Now(),
-		label:    []rune(gap + cyclingCharsLabel),
+		label:    []rune(gap + label),
 		ellipsis: spinner.New(spinner.WithSpinner(ellipsisSpinner)),
 		styles:   s,
 	}

--- a/mods.go
+++ b/mods.go
@@ -57,7 +57,7 @@ func newMods(cfg config, r *lipgloss.Renderer) *Mods {
 		state:    startState,
 		renderer: r,
 		styles:   s,
-		anim:     newCyclingChars(cfg.Fanciness, r, s),
+		anim:     newCyclingChars(cfg.Fanciness, cfg.StatusText, r, s),
 	}
 }
 


### PR DESCRIPTION
This introduces the `--status-text` and `STATUS_TEXT` argument and environment variable for customizing text displayed in the 'generating' animation. I found myself wanting this feature to provide some extra context to the user when writing scripts with `mods`.

```
$ ./generate-kamojis cat
7&AB%^J_8E Generating cat kamojis...
```

Suggestions on the argument and environment variable naming is welcome.