### PR TITLE
chore: use ellipsis spinner ported to Bubbles

### DIFF
--- a/anim.go
+++ b/anim.go
@@ -18,14 +18,7 @@ const (
 	maxCyclingChars = 120
 )
 
-var (
-	charRunes = []rune("0123456789abcdefABCDEF~!@#$£€%^&*()+=_")
-
-	ellipsisSpinner = spinner.Spinner{
-		Frames: []string{"", ".", "..", "..."},
-		FPS:    time.Second / 3, //nolint:gomnd
-	}
-)
+var charRunes = []rune("0123456789abcdefABCDEF~!@#$£€%^&*()+=_")
 
 type charState int
 
@@ -101,7 +94,7 @@ func newAnim(cyclingCharsSize uint, label string, r *lipgloss.Renderer, s styles
 	c := anim{
 		start:    time.Now(),
 		label:    []rune(gap + label),
-		ellipsis: spinner.New(spinner.WithSpinner(ellipsisSpinner)),
+		ellipsis: spinner.New(spinner.WithSpinner(spinner.Ellipsis)),
 		styles:   s,
 	}
 


### PR DESCRIPTION
Since releasing Mods we've ported the periods of ellipsis spinner (the three dots in `Generating...`) to [Bubbles](https://github.com/charmbracelet/bubbles). This update switches to the version in Bubbles.