### PR TITLE
feat: add ability to continue, save, and manage conversations

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ Backup your old settings file and reset everything to the defaults.
 
 #### No Cache
 
-`--no-cache`, `MODS_NO_LIMIT`
+`--no-cache`, `MODS_NO_CACHE`
 
 Disable saving and reading the most recent prompt/response.
 

--- a/README.md
+++ b/README.md
@@ -128,6 +128,18 @@ sent without `-c`.
 Providing a name will automatically save the conversation with that name if it
 doesn't already exist.
 
+#### List
+
+`-l`, `--list`
+
+Lists all saved conversations.
+
+#### Delete
+
+`--delete`
+
+Deletes the saved conversation with the given name.
+
 #### Format As Markdown
 
 `-f`, `--format`, `MODS_FORMAT`

--- a/README.md
+++ b/README.md
@@ -108,6 +108,15 @@ You can add new models to the settings with `mods -s`. You can also specify a
 model and an API endpoint with `-m` and `-a` to use models not in the settings
 file.
 
+#### Continue
+
+`-c`, `--continue`
+
+Continue from the last response. 
+
+Additional instances of `-c` will continue the conversation. Once a prompt is
+sent without `-c` the previous context is lost.
+
 #### Format As Markdown
 
 `-f`, `--format`, `MODS_FORMAT`
@@ -185,6 +194,12 @@ Output nothing to standard err.
 `--reset-settings`
 
 Backup your old settings file and reset everything to the defaults.
+
+#### No Cache
+
+`--no-cache`, `MODS_NO_LIMIT`
+
+Disable saving and reading the most recent prompt/response.
 
 ## Whatcha Think?
 

--- a/README.md
+++ b/README.md
@@ -108,14 +108,25 @@ You can add new models to the settings with `mods -s`. You can also specify a
 model and an API endpoint with `-m` and `-a` to use models not in the settings
 file.
 
+#### Save
+
+`--save`
+
+Saves the conversation with the given name. Continue the conversation back with
+`-c` and pass the name.
+
+
 #### Continue
 
 `-c`, `--continue`
 
-Continue from the last response. 
+Continue from the last response or a given name.
 
 Additional instances of `-c` will continue the conversation. Once a prompt is
-sent without `-c` the previous context is lost.
+sent without `-c`.
+
+Providing a name will automatically save the conversation with that name if it
+doesn't already exist.
 
 #### Format As Markdown
 

--- a/cache.go
+++ b/cache.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"encoding/gob"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	openai "github.com/sashabaranov/go-openai"
+)
+
+var cacheExt = ".gob"
+var defaultCacheName = "_current" + cacheExt
+
+func ReadCache(name string, messages *[]openai.ChatCompletionMessage, cfg Config) error {
+	if !strings.HasSuffix(name, cacheExt) {
+		name += cacheExt
+	}
+
+	file, err := os.Open(filepath.Join(cfg.CachePath, name))
+	if err != nil {
+		return err
+	}
+	defer file.Close() //nolint:errcheck
+
+	decoder := gob.NewDecoder(file)
+	err = decoder.Decode(messages)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func WriteCache(name string, messages *[]openai.ChatCompletionMessage, cfg Config) error {
+	if !strings.HasSuffix(name, cacheExt) {
+		name += cacheExt
+	}
+
+	err := os.MkdirAll(cfg.CachePath, 0o700)
+	if err != nil {
+		return err
+	}
+
+	file, err := os.Create(filepath.Join(cfg.CachePath, name))
+	if err != nil {
+		return err
+	}
+	defer file.Close() //nolint:errcheck
+
+	encoder := gob.NewEncoder(file)
+	err = encoder.Encode(messages)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func SaveCache(cfg Config) error {
+	inputFile, err := os.Open(filepath.Join(cfg.CachePath, defaultCacheName))
+	if err != nil {
+		return err
+	}
+	defer inputFile.Close() //nolint:errcheck
+	outputFile, err := os.Create(filepath.Join(cfg.CachePath, cfg.Save+cacheExt))
+	if err != nil {
+		return err
+	}
+	defer outputFile.Close() //nolint:errcheck
+	_, err = io.Copy(outputFile, inputFile)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func ListCache(cfg Config) ([]string, error) {
+	entries, err := os.ReadDir(cfg.CachePath)
+	if err != nil {
+		return nil, err
+	}
+
+	files := []string{}
+	for _, entry := range entries {
+		if entry.IsDir() || entry.Name() == defaultCacheName {
+			continue
+		}
+
+		files = append(files, strings.TrimSuffix(entry.Name(), cacheExt))
+	}
+
+	return files, nil
+}
+
+func DeleteCache(cfg Config) error {
+	return os.Remove(filepath.Join(cfg.CachePath, cfg.Delete+cacheExt))
+}

--- a/cache.go
+++ b/cache.go
@@ -13,7 +13,7 @@ import (
 var cacheExt = ".gob"
 var defaultCacheName = "_current" + cacheExt
 
-func ReadCache(name string, messages *[]openai.ChatCompletionMessage, cfg Config) error {
+func readCache(name string, messages *[]openai.ChatCompletionMessage, cfg Config) error {
 	if !strings.HasSuffix(name, cacheExt) {
 		name += cacheExt
 	}
@@ -33,7 +33,7 @@ func ReadCache(name string, messages *[]openai.ChatCompletionMessage, cfg Config
 	return nil
 }
 
-func WriteCache(name string, messages *[]openai.ChatCompletionMessage, cfg Config) error {
+func writeCache(name string, messages *[]openai.ChatCompletionMessage, cfg Config) error {
 	if !strings.HasSuffix(name, cacheExt) {
 		name += cacheExt
 	}
@@ -58,7 +58,7 @@ func WriteCache(name string, messages *[]openai.ChatCompletionMessage, cfg Confi
 	return nil
 }
 
-func SaveCache(cfg Config) error {
+func saveCache(cfg Config) error {
 	inputFile, err := os.Open(filepath.Join(cfg.CachePath, defaultCacheName))
 	if err != nil {
 		return err
@@ -77,7 +77,7 @@ func SaveCache(cfg Config) error {
 	return nil
 }
 
-func ListCache(cfg Config) ([]string, error) {
+func listCache(cfg Config) ([]string, error) {
 	entries, err := os.ReadDir(cfg.CachePath)
 	if err != nil {
 		return nil, err
@@ -95,6 +95,6 @@ func ListCache(cfg Config) ([]string, error) {
 	return files, nil
 }
 
-func DeleteCache(cfg Config) error {
+func deleteCache(cfg Config) error {
 	return os.Remove(filepath.Join(cfg.CachePath, cfg.Delete+cacheExt))
 }

--- a/config.go
+++ b/config.go
@@ -36,7 +36,7 @@ var help = map[string]string{
 	"status-text":     "Text to show while generating.",
 	"settings":        "Open settings in your $EDITOR.",
 	"reset-settings":  "Reset settings to the defaults, your old settings file will be backed up.",
-	"continue":        "Continue from the last response.",
+	"continue":        "Continue from the last response or a given save name.",
 	"no-cache":        "Disables caching of the prompt/response.",
 	"save":            "Saves the current conversation with the given name.",
 }
@@ -101,7 +101,7 @@ type Config struct {
 	Settings          bool
 	SettingsPath      string
 	CachePath         string
-	Continue          bool
+	Continue          string
 	Save              string
 }
 
@@ -178,7 +178,7 @@ func newConfig() (Config, error) {
 	flag.BoolVarP(&c.Settings, "settings", "s", false, help["settings"])
 	flag.BoolVarP(&c.ShowHelp, "help", "h", false, help["help"])
 	flag.BoolVarP(&c.Version, "version", "v", false, help["version"])
-	flag.BoolVarP(&c.Continue, "continue", "c", c.Continue, help["continue"]) // TODO: allow continuing by name
+	flag.StringVarP(&c.Continue, "continue", "c", "", help["continue"])
 	flag.IntVar(&c.MaxRetries, "max-retries", c.MaxRetries, help["max-retries"])
 	flag.BoolVar(&c.NoLimit, "no-limit", c.NoLimit, help["no-limit"])
 	flag.IntVar(&c.MaxTokens, "max-tokens", c.MaxTokens, help["max-tokens"])
@@ -190,6 +190,7 @@ func newConfig() (Config, error) {
 	flag.StringVar(&c.Save, "save", c.Save, help["save"])
 	flag.BoolVar(&c.NoCache, "no-cache", c.NoCache, help["no-cache"])
 	flag.Lookup("prompt").NoOptDefVal = "-1"
+	flag.Lookup("continue").NoOptDefVal = "_current.gob"
 	flag.Usage = usage
 	flag.CommandLine.SortFlags = false
 	flag.CommandLine.Init("", flag.ContinueOnError)
@@ -200,6 +201,10 @@ func newConfig() (Config, error) {
 		c.FormatText = "Format the response as markdown without enclosing backticks."
 	}
 	c.Prefix = strings.Join(flag.Args(), " ")
+
+	if c.Continue != "" && !strings.HasSuffix(c.Continue, ".gob") {
+		c.Continue += ".gob"
+	}
 
 	return c, nil
 }

--- a/config.go
+++ b/config.go
@@ -38,6 +38,7 @@ var help = map[string]string{
 	"reset-settings":  "Reset settings to the defaults, your old settings file will be backed up.",
 	"continue":        "Continue from the last response.",
 	"no-cache":        "Disables caching of the prompt/response.",
+	"save":            "Saves the current conversation with the given name.",
 }
 
 // Model represents the LLM model used in the API call.
@@ -99,7 +100,9 @@ type Config struct {
 	Version           bool
 	Settings          bool
 	SettingsPath      string
+	CachePath         string
 	Continue          bool
+	Save              string
 }
 
 type flagParseError struct {
@@ -124,6 +127,7 @@ func (f flagParseError) Flag() string {
 
 func newConfig() (Config, error) {
 	var c Config
+	c.CachePath = filepath.Join(xdg.Home, "mods", "conversations")
 	sp, err := xdg.ConfigFile(filepath.Join("mods", "mods.yml"))
 	if err != nil {
 		return c, fmt.Errorf("can't find settings path: %s", err)
@@ -174,7 +178,7 @@ func newConfig() (Config, error) {
 	flag.BoolVarP(&c.Settings, "settings", "s", false, help["settings"])
 	flag.BoolVarP(&c.ShowHelp, "help", "h", false, help["help"])
 	flag.BoolVarP(&c.Version, "version", "v", false, help["version"])
-	flag.BoolVarP(&c.Continue, "continue", "c", c.Continue, help["continue"])
+	flag.BoolVarP(&c.Continue, "continue", "c", c.Continue, help["continue"]) // TODO: allow continuing by name
 	flag.IntVar(&c.MaxRetries, "max-retries", c.MaxRetries, help["max-retries"])
 	flag.BoolVar(&c.NoLimit, "no-limit", c.NoLimit, help["no-limit"])
 	flag.IntVar(&c.MaxTokens, "max-tokens", c.MaxTokens, help["max-tokens"])
@@ -183,6 +187,7 @@ func newConfig() (Config, error) {
 	flag.UintVar(&c.Fanciness, "fanciness", c.Fanciness, help["fanciness"])
 	flag.StringVar(&c.StatusText, "status-text", c.StatusText, help["status-text"])
 	flag.BoolVar(&c.ResetSettings, "reset-settings", c.ResetSettings, help["reset-settings"])
+	flag.StringVar(&c.Save, "save", c.Save, help["save"])
 	flag.BoolVar(&c.NoCache, "no-cache", c.NoCache, help["no-cache"])
 	flag.Lookup("prompt").NoOptDefVal = "-1"
 	flag.Usage = usage

--- a/config.go
+++ b/config.go
@@ -86,6 +86,7 @@ type Config struct {
 	Temperature       float32 `yaml:"temp" env:"TEMP"`
 	TopP              float32 `yaml:"topp" env:"TOPP"`
 	NoLimit           bool    `yaml:"no-limit" env:"NO_LIMIT"`
+	CachePath         string  `yaml:"cache-path" env:"CACHE_PATH"`
 	NoCache           bool    `yaml:"no-cache" env:"NO_CACHE"`
 	IncludePromptArgs bool    `yaml:"include-prompt-args" env:"INCLUDE_PROMPT_ARGS"`
 	IncludePrompt     int     `yaml:"include-prompt" env:"INCLUDE_PROMPT"`
@@ -102,7 +103,6 @@ type Config struct {
 	Version           bool
 	Settings          bool
 	SettingsPath      string
-	CachePath         string
 	Continue          string
 	Save              string
 	List              bool
@@ -131,7 +131,6 @@ func (f flagParseError) Flag() string {
 
 func newConfig() (Config, error) {
 	var c Config
-	c.CachePath = filepath.Join(xdg.DataHome, "mods", "conversations")
 	sp, err := xdg.ConfigFile(filepath.Join("mods", "mods.yml"))
 	if err != nil {
 		return c, fmt.Errorf("can't find settings path: %s", err)
@@ -205,6 +204,9 @@ func newConfig() (Config, error) {
 	}
 	if c.Format && c.FormatText == "" {
 		c.FormatText = "Format the response as markdown without enclosing backticks."
+	}
+	if c.CachePath == "" {
+		c.CachePath = filepath.Join(xdg.DataHome, "mods", "conversations")
 	}
 	c.Prefix = strings.Join(flag.Args(), " ")
 

--- a/config.go
+++ b/config.go
@@ -127,7 +127,7 @@ func (f flagParseError) Flag() string {
 
 func newConfig() (Config, error) {
 	var c Config
-	c.CachePath = filepath.Join(xdg.Home, "mods", "conversations")
+	c.CachePath = filepath.Join(xdg.DataHome, "mods", "conversations")
 	sp, err := xdg.ConfigFile(filepath.Join("mods", "mods.yml"))
 	if err != nil {
 		return c, fmt.Errorf("can't find settings path: %s", err)

--- a/config.go
+++ b/config.go
@@ -36,6 +36,8 @@ var help = map[string]string{
 	"status-text":     "Text to show while generating.",
 	"settings":        "Open settings in your $EDITOR.",
 	"reset-settings":  "Reset settings to the defaults, your old settings file will be backed up.",
+	"continue":        "Continue from the last response.",
+	"no-cache":        "Disables caching of the prompt/response.",
 }
 
 // Model represents the LLM model used in the API call.
@@ -81,6 +83,7 @@ type Config struct {
 	Temperature       float32 `yaml:"temp" env:"TEMP"`
 	TopP              float32 `yaml:"topp" env:"TOPP"`
 	NoLimit           bool    `yaml:"no-limit" env:"NO_LIMIT"`
+	NoCache           bool    `yaml:"no-cache" env:"NO_CACHE"`
 	IncludePromptArgs bool    `yaml:"include-prompt-args" env:"INCLUDE_PROMPT_ARGS"`
 	IncludePrompt     int     `yaml:"include-prompt" env:"INCLUDE_PROMPT"`
 	MaxRetries        int     `yaml:"max-retries" env:"MAX_RETRIES"`
@@ -96,6 +99,7 @@ type Config struct {
 	Version           bool
 	Settings          bool
 	SettingsPath      string
+	Continue          bool
 }
 
 type flagParseError struct {
@@ -170,6 +174,7 @@ func newConfig() (Config, error) {
 	flag.BoolVarP(&c.Settings, "settings", "s", false, help["settings"])
 	flag.BoolVarP(&c.ShowHelp, "help", "h", false, help["help"])
 	flag.BoolVarP(&c.Version, "version", "v", false, help["version"])
+	flag.BoolVarP(&c.Continue, "continue", "c", c.Continue, help["continue"])
 	flag.IntVar(&c.MaxRetries, "max-retries", c.MaxRetries, help["max-retries"])
 	flag.BoolVar(&c.NoLimit, "no-limit", c.NoLimit, help["no-limit"])
 	flag.IntVar(&c.MaxTokens, "max-tokens", c.MaxTokens, help["max-tokens"])
@@ -178,6 +183,7 @@ func newConfig() (Config, error) {
 	flag.UintVar(&c.Fanciness, "fanciness", c.Fanciness, help["fanciness"])
 	flag.StringVar(&c.StatusText, "status-text", c.StatusText, help["status-text"])
 	flag.BoolVar(&c.ResetSettings, "reset-settings", c.ResetSettings, help["reset-settings"])
+	flag.BoolVar(&c.NoCache, "no-cache", c.NoCache, help["no-cache"])
 	flag.Lookup("prompt").NoOptDefVal = "-1"
 	flag.Usage = usage
 	flag.CommandLine.SortFlags = false

--- a/config.go
+++ b/config.go
@@ -39,6 +39,8 @@ var help = map[string]string{
 	"continue":        "Continue from the last response or a given save name.",
 	"no-cache":        "Disables caching of the prompt/response.",
 	"save":            "Saves the current conversation with the given name.",
+	"list":            "Lists saved conversations.",
+	"delete":          "Deletes a saved conversation with the given name.",
 }
 
 // Model represents the LLM model used in the API call.
@@ -103,6 +105,8 @@ type Config struct {
 	CachePath         string
 	Continue          string
 	Save              string
+	List              bool
+	Delete            string
 }
 
 type flagParseError struct {
@@ -179,6 +183,7 @@ func newConfig() (Config, error) {
 	flag.BoolVarP(&c.ShowHelp, "help", "h", false, help["help"])
 	flag.BoolVarP(&c.Version, "version", "v", false, help["version"])
 	flag.StringVarP(&c.Continue, "continue", "c", "", help["continue"])
+	flag.BoolVarP(&c.List, "list", "l", c.List, help["list"])
 	flag.IntVar(&c.MaxRetries, "max-retries", c.MaxRetries, help["max-retries"])
 	flag.BoolVar(&c.NoLimit, "no-limit", c.NoLimit, help["no-limit"])
 	flag.IntVar(&c.MaxTokens, "max-tokens", c.MaxTokens, help["max-tokens"])
@@ -188,9 +193,10 @@ func newConfig() (Config, error) {
 	flag.StringVar(&c.StatusText, "status-text", c.StatusText, help["status-text"])
 	flag.BoolVar(&c.ResetSettings, "reset-settings", c.ResetSettings, help["reset-settings"])
 	flag.StringVar(&c.Save, "save", c.Save, help["save"])
+	flag.StringVar(&c.Delete, "delete", c.Delete, help["delete"])
 	flag.BoolVar(&c.NoCache, "no-cache", c.NoCache, help["no-cache"])
 	flag.Lookup("prompt").NoOptDefVal = "-1"
-	flag.Lookup("continue").NoOptDefVal = "_current.gob"
+	flag.Lookup("continue").NoOptDefVal = defaultCacheName
 	flag.Usage = usage
 	flag.CommandLine.SortFlags = false
 	flag.CommandLine.Init("", flag.ContinueOnError)
@@ -201,10 +207,6 @@ func newConfig() (Config, error) {
 		c.FormatText = "Format the response as markdown without enclosing backticks."
 	}
 	c.Prefix = strings.Join(flag.Args(), " ")
-
-	if c.Continue != "" && !strings.HasSuffix(c.Continue, ".gob") {
-		c.Continue += ".gob"
-	}
 
 	return c, nil
 }

--- a/main.go
+++ b/main.go
@@ -110,7 +110,7 @@ func main() {
 		os.Exit(0)
 	}
 	if mods.Config.Save != "" {
-		err := SaveCache(mods.Config)
+		err := saveCache(mods.Config)
 		if err != nil {
 			exitError(mods, err, "Couldn't save conversation.")
 		}
@@ -120,7 +120,7 @@ func main() {
 		os.Exit(0)
 	}
 	if mods.Config.List {
-		conversations, err := ListCache(mods.Config)
+		conversations, err := listCache(mods.Config)
 		if err != nil {
 			exitError(mods, err, "Couldn't list saves.")
 		}
@@ -135,7 +135,7 @@ func main() {
 		os.Exit(0)
 	}
 	if mods.Config.Delete != "" {
-		err := DeleteCache(mods.Config)
+		err := deleteCache(mods.Config)
 		if err != nil {
 			exitError(mods, err, "Couldn't delete conversation.")
 		}

--- a/main.go
+++ b/main.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path/filepath"
 	"runtime/debug"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -111,22 +110,37 @@ func main() {
 		os.Exit(0)
 	}
 	if mods.Config.Save != "" {
-		inputFile, err := os.Open(filepath.Join(mods.Config.CachePath, "_current.gob"))
+		err := SaveCache(mods.Config)
 		if err != nil {
-			exitError(mods, err, "Couldn't read current conversation.")
-		}
-		defer inputFile.Close() //nolint:errcheck
-		outputFile, err := os.Create(filepath.Join(mods.Config.CachePath, mods.Config.Save+".gob"))
-		if err != nil {
-			exitError(mods, err, "Couldn't create save.")
-		}
-		defer outputFile.Close() //nolint:errcheck
-		_, err = io.Copy(outputFile, inputFile)
-		if err != nil {
-			exitError(mods, err, "Couldn't write to save.")
+			exitError(mods, err, "Couldn't save conversation.")
 		}
 
-		fmt.Println("Conversation saved:", mods.Config.Save)
+		fmt.Println("  Conversation saved:", mods.Config.Save)
+
+		os.Exit(0)
+	}
+	if mods.Config.List {
+		conversations, err := ListCache(mods.Config)
+		if err != nil {
+			exitError(mods, err, "Couldn't list saves.")
+		}
+
+		fmt.Printf("  Saved conversations %s:\n", mods.Styles.Comment.Render("("+fmt.Sprint(len(conversations))+")"))
+		for _, conversation := range conversations {
+			fmt.Printf("  %s %s\n",
+				mods.Styles.Comment.Render("•"),
+				conversation,
+			)
+		}
+		os.Exit(0)
+	}
+	if mods.Config.Delete != "" {
+		err := DeleteCache(mods.Config)
+		if err != nil {
+			exitError(mods, err, "Couldn't delete conversation.")
+		}
+
+		fmt.Println("  Conversation deleted:", mods.Config.Delete)
 
 		os.Exit(0)
 	}

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"runtime/debug"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -107,6 +108,26 @@ func main() {
 			mods.Styles.Comment.Render("Your old settings are have been saved to:"),
 			mods.Styles.Link.Render(mods.Config.SettingsPath+".bak"),
 		)
+		os.Exit(0)
+	}
+	if mods.Config.Save != "" {
+		inputFile, err := os.Open(filepath.Join(mods.Config.CachePath, "_current.gob"))
+		if err != nil {
+			exitError(mods, err, "Couldn't read current conversation.")
+		}
+		defer inputFile.Close() //nolint:errcheck
+		outputFile, err := os.Create(filepath.Join(mods.Config.CachePath, mods.Config.Save+".gob"))
+		if err != nil {
+			exitError(mods, err, "Couldn't create save.")
+		}
+		defer outputFile.Close() //nolint:errcheck
+		_, err = io.Copy(outputFile, inputFile)
+		if err != nil {
+			exitError(mods, err, "Couldn't write to save.")
+		}
+
+		fmt.Println("Conversation saved:", mods.Config.Save)
+
 		os.Exit(0)
 	}
 	if mods.Config.Version {

--- a/mods.go
+++ b/mods.go
@@ -369,9 +369,11 @@ func (m *Mods) startCompletionCmd(content string) tea.Cmd {
 		respMessage := resp.Choices[0].Message
 		if !cfg.NoCache {
 			messages = append(messages, respMessage)
-			err = writeCache(cfg.Continue, &messages, cfg)
-			if err != nil {
-				return modsError{err: err, reason: fmt.Sprintf("There was a problem writing %s to the cache. Use --no-cache / MODS_NO_CACHE to disable it.", cfg.Continue)}
+			if cfg.Continue != "" {
+				err = writeCache(cfg.Continue, &messages, cfg)
+				if err != nil {
+					return modsError{err: err, reason: fmt.Sprintf("There was a problem writing %s to the cache. Use --no-cache / MODS_NO_CACHE to disable it.", cfg.Continue)}
+				}
 			}
 			if cfg.Continue != "_current.gob" {
 				writeCache("_current.gob", &messages, cfg)
@@ -390,7 +392,7 @@ func readCache(name string, messages *[]openai.ChatCompletionMessage, cfg Config
 	if err != nil {
 		return err
 	}
-	defer file.Close()
+	defer file.Close() //nolint:errcheck
 
 	decoder := gob.NewDecoder(file)
 	err = decoder.Decode(messages)
@@ -411,7 +413,7 @@ func writeCache(name string, messages *[]openai.ChatCompletionMessage, cfg Confi
 	if err != nil {
 		return err
 	}
-	defer file.Close()
+	defer file.Close() //nolint:errcheck
 
 	encoder := gob.NewEncoder(file)
 	err = encoder.Encode(messages)

--- a/mods.go
+++ b/mods.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"math"
 	"net/http"
 	"os"
@@ -14,6 +15,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/adrg/xdg"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/mattn/go-isatty"
@@ -304,8 +306,8 @@ func (m *Mods) startCompletionCmd(content string) tea.Cmd {
 			}
 		}
 
-		tmpDir := os.TempDir()
-		filePath := filepath.Join(tmpDir, "mods.gob")
+		tmpDir := filepath.Join(xdg.Home, "mods", "conversations")
+		filePath := filepath.Join(tmpDir, "_current.gob")
 
 		messages := []openai.ChatCompletionMessage{}
 		if cfg.Continue && !cfg.NoCache {
@@ -393,6 +395,11 @@ func readCache(path string, messages *[]openai.ChatCompletionMessage) error {
 }
 
 func writeCache(path string, messages *[]openai.ChatCompletionMessage) error {
+	err := os.MkdirAll(filepath.Dir(path), fs.ModePerm)
+	if err != nil {
+		return err
+	}
+
 	file, err := os.Create(path)
 	if err != nil {
 		return err

--- a/mods.go
+++ b/mods.go
@@ -306,7 +306,10 @@ func (m *Mods) startCompletionCmd(content string) tea.Cmd {
 
 		messages := []openai.ChatCompletionMessage{}
 		if cfg.Continue != "" && !cfg.NoCache {
-			readCache(cfg.Continue, &messages, cfg)
+			err := readCache(cfg.Continue, &messages, cfg)
+			if err != nil {
+				return modsError{err: err, reason: "There was a problem writing to the cache. Use `--no-cache`/`MODS_NO_CACHE` to disable it."}
+			}
 		}
 
 		messages = append(messages, openai.ChatCompletionMessage{
@@ -366,9 +369,15 @@ func (m *Mods) startCompletionCmd(content string) tea.Cmd {
 		respMessage := resp.Choices[0].Message
 		if !cfg.NoCache {
 			messages = append(messages, respMessage)
-			writeCache(cfg.Continue, &messages, cfg)
+			err = writeCache(cfg.Continue, &messages, cfg)
+			if err != nil {
+				return modsError{err: err, reason: "There was a problem writing to the cache. Use `--no-cache`/`MODS_NO_CACHE` to disable it."}
+			}
 			if cfg.Continue != "_current.gob" {
 				writeCache("_current.gob", &messages, cfg)
+				if err != nil {
+					return modsError{err: err, reason: "There was a problem writing to the cache. Use `--no-cache`/`MODS_NO_CACHE` to disable it."}
+				}
 			}
 		}
 

--- a/mods.go
+++ b/mods.go
@@ -306,7 +306,10 @@ func (m *Mods) startCompletionCmd(content string) tea.Cmd {
 		if cfg.Continue != "" && !cfg.NoCache {
 			err := ReadCache(cfg.Continue, &messages, cfg)
 			if err != nil {
-				return modsError{err: err, reason: "There was a problem reading the cache. Use --no-cache / MODS_NO_CACHE to disable it."}
+				return modsError{
+					err:    err,
+					reason: fmt.Sprintf("There was a problem reading the cache. Use %s / %s to disable it.", m.Styles.InlineCode.Render("--no-cache"), m.Styles.InlineCode.Render("NO_CACHE")),
+				}
 			}
 		}
 
@@ -370,13 +373,19 @@ func (m *Mods) startCompletionCmd(content string) tea.Cmd {
 			if cfg.Continue != "" {
 				err = WriteCache(cfg.Continue, &messages, cfg)
 				if err != nil {
-					return modsError{err: err, reason: fmt.Sprintf("There was a problem writing %s to the cache. Use --no-cache / MODS_NO_CACHE to disable it.", cfg.Continue)}
+					return modsError{
+						err:    err,
+						reason: fmt.Sprintf("There was a problem writing %s to the cache. Use %s / %s to disable it.", cfg.Continue, m.Styles.InlineCode.Render("--no-cache"), m.Styles.InlineCode.Render("NO_CACHE")),
+					}
 				}
 			}
 			if cfg.Continue != defaultCacheName {
 				WriteCache(defaultCacheName, &messages, cfg)
 				if err != nil {
-					return modsError{err: err, reason: fmt.Sprintf("There was a problem writing %s to the cache. Use --no-cache / MODS_NO_CACHE to disable it.", cfg.Continue)}
+					return modsError{
+						err:    err,
+						reason: fmt.Sprintf("There was a problem writing %s to the cache. Use %s / %s to disable it.", cfg.Continue, m.Styles.InlineCode.Render("--no-cache"), m.Styles.InlineCode.Render("NO_CACHE")),
+					}
 				}
 			}
 		}

--- a/mods.go
+++ b/mods.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/fs"
 	"math"
 	"net/http"
 	"os"
@@ -395,7 +394,7 @@ func readCache(path string, messages *[]openai.ChatCompletionMessage) error {
 }
 
 func writeCache(path string, messages *[]openai.ChatCompletionMessage) error {
-	err := os.MkdirAll(filepath.Dir(path), fs.ModePerm)
+	err := os.MkdirAll(filepath.Dir(path), 0o700)
 	if err != nil {
 		return err
 	}

--- a/mods.go
+++ b/mods.go
@@ -308,7 +308,7 @@ func (m *Mods) startCompletionCmd(content string) tea.Cmd {
 		if cfg.Continue != "" && !cfg.NoCache {
 			err := readCache(cfg.Continue, &messages, cfg)
 			if err != nil {
-				return modsError{err: err, reason: "There was a problem writing to the cache. Use `--no-cache`/`MODS_NO_CACHE` to disable it."}
+				return modsError{err: err, reason: "There was a problem reading the cache. Use --no-cache / MODS_NO_CACHE to disable it."}
 			}
 		}
 
@@ -371,12 +371,12 @@ func (m *Mods) startCompletionCmd(content string) tea.Cmd {
 			messages = append(messages, respMessage)
 			err = writeCache(cfg.Continue, &messages, cfg)
 			if err != nil {
-				return modsError{err: err, reason: "There was a problem writing to the cache. Use `--no-cache`/`MODS_NO_CACHE` to disable it."}
+				return modsError{err: err, reason: fmt.Sprintf("There was a problem writing %s to the cache. Use --no-cache / MODS_NO_CACHE to disable it.", cfg.Continue)}
 			}
 			if cfg.Continue != "_current.gob" {
 				writeCache("_current.gob", &messages, cfg)
 				if err != nil {
-					return modsError{err: err, reason: "There was a problem writing to the cache. Use `--no-cache`/`MODS_NO_CACHE` to disable it."}
+					return modsError{err: err, reason: fmt.Sprintf("There was a problem writing %s to the cache. Use --no-cache / MODS_NO_CACHE to disable it.", cfg.Continue)}
 				}
 			}
 		}

--- a/mods.go
+++ b/mods.go
@@ -304,7 +304,7 @@ func (m *Mods) startCompletionCmd(content string) tea.Cmd {
 
 		messages := []openai.ChatCompletionMessage{}
 		if cfg.Continue != "" && !cfg.NoCache {
-			err := ReadCache(cfg.Continue, &messages, cfg)
+			err := readCache(cfg.Continue, &messages, cfg)
 			if err != nil {
 				return modsError{
 					err:    err,
@@ -371,7 +371,7 @@ func (m *Mods) startCompletionCmd(content string) tea.Cmd {
 		if !cfg.NoCache {
 			messages = append(messages, respMessage)
 			if cfg.Continue != "" {
-				err = WriteCache(cfg.Continue, &messages, cfg)
+				err = writeCache(cfg.Continue, &messages, cfg)
 				if err != nil {
 					return modsError{
 						err:    err,
@@ -380,7 +380,7 @@ func (m *Mods) startCompletionCmd(content string) tea.Cmd {
 				}
 			}
 			if cfg.Continue != defaultCacheName {
-				WriteCache(defaultCacheName, &messages, cfg)
+				err = writeCache(defaultCacheName, &messages, cfg)
 				if err != nil {
 					return modsError{
 						err:    err,

--- a/mods.go
+++ b/mods.go
@@ -306,7 +306,7 @@ func (m *Mods) startCompletionCmd(content string) tea.Cmd {
 
 		messages := []openai.ChatCompletionMessage{}
 		if cfg.Continue != "" && !cfg.NoCache {
-			readCache(filepath.Join(cfg.CachePath, cfg.Continue), &messages)
+			readCache(cfg.Continue, &messages, cfg)
 		}
 
 		messages = append(messages, openai.ChatCompletionMessage{
@@ -366,9 +366,9 @@ func (m *Mods) startCompletionCmd(content string) tea.Cmd {
 		respMessage := resp.Choices[0].Message
 		if !cfg.NoCache {
 			messages = append(messages, respMessage)
-			writeCache(filepath.Join(cfg.CachePath, cfg.Continue), &messages)
+			writeCache(cfg.Continue, &messages, cfg)
 			if cfg.Continue != "_current.gob" {
-				writeCache(filepath.Join(cfg.CachePath, "_current.gob"), &messages)
+				writeCache("_current.gob", &messages, cfg)
 			}
 		}
 
@@ -376,8 +376,8 @@ func (m *Mods) startCompletionCmd(content string) tea.Cmd {
 	}
 }
 
-func readCache(path string, messages *[]openai.ChatCompletionMessage) error {
-	file, err := os.Open(path)
+func readCache(name string, messages *[]openai.ChatCompletionMessage, cfg Config) error {
+	file, err := os.Open(filepath.Join(cfg.CachePath, name))
 	if err != nil {
 		return err
 	}
@@ -392,13 +392,13 @@ func readCache(path string, messages *[]openai.ChatCompletionMessage) error {
 	return nil
 }
 
-func writeCache(path string, messages *[]openai.ChatCompletionMessage) error {
-	err := os.MkdirAll(filepath.Dir(path), 0o700)
+func writeCache(name string, messages *[]openai.ChatCompletionMessage, cfg Config) error {
+	err := os.MkdirAll(cfg.CachePath, 0o700)
 	if err != nil {
 		return err
 	}
 
-	file, err := os.Create(path)
+	file, err := os.Create(filepath.Join(cfg.CachePath, name))
 	if err != nil {
 		return err
 	}

--- a/mods.go
+++ b/mods.go
@@ -14,7 +14,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/adrg/xdg"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/mattn/go-isatty"
@@ -305,12 +304,9 @@ func (m *Mods) startCompletionCmd(content string) tea.Cmd {
 			}
 		}
 
-		tmpDir := filepath.Join(xdg.Home, "mods", "conversations")
-		filePath := filepath.Join(tmpDir, "_current.gob")
-
 		messages := []openai.ChatCompletionMessage{}
-		if cfg.Continue && !cfg.NoCache {
-			readCache(filePath, &messages)
+		if cfg.Continue != "" && !cfg.NoCache {
+			readCache(filepath.Join(cfg.CachePath, cfg.Continue), &messages)
 		}
 
 		messages = append(messages, openai.ChatCompletionMessage{
@@ -370,7 +366,10 @@ func (m *Mods) startCompletionCmd(content string) tea.Cmd {
 		respMessage := resp.Choices[0].Message
 		if !cfg.NoCache {
 			messages = append(messages, respMessage)
-			writeCache(filePath, &messages)
+			writeCache(filepath.Join(cfg.CachePath, cfg.Continue), &messages)
+			if cfg.Continue != "_current.gob" {
+				writeCache(filepath.Join(cfg.CachePath, "_current.gob"), &messages)
+			}
 		}
 
 		return completionOutput{respMessage.Content}


### PR DESCRIPTION
Adds `--continue`/`-c` to allow continuing the conversation from the last prompt/response.

Stores the most recent conversation in a temp file unless `--no-cache` is specified.