### PR TITLE
feat: add support for HTTP proxy in the configuration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,12 @@ Backup your old settings file and reset everything to the defaults.
 
 Disable saving and reading the most recent prompt/response.
 
+
+#### HTTP Proxy
+`-x`, `--http-proxy`, `MODS_HTTP_PROXY`
+
+Use the HTTP proxy to the connect the API endpoints.
+
 ## Whatcha Think?
 
 We’d love to hear your thoughts on this project. Feel free to drop us a note.

--- a/config.go
+++ b/config.go
@@ -18,6 +18,7 @@ import (
 var help = map[string]string{
 	"api":             "OpenAI compatible REST API (openai, localai).",
 	"apis":            "Aliases and endpoints for OpenAI compatible REST API.",
+	"http-proxy":      "HTTP proxy to use for API requests.",
 	"model":           "Default model (gpt-3.5-turbo, gpt-4, ggml-gpt4all-j...).",
 	"max-input-chars": "Default character limit on input to model.",
 	"format":          "Ask for the response to be formatted as markdown (default).",
@@ -94,6 +95,7 @@ type Config struct {
 	Fanciness         uint    `yaml:"fanciness" env:"FANCINESS"`
 	StatusText        string  `yaml:"status-text" env:"STATUS_TEXT"`
 	FormatText        string  `yaml:"format-text" env:"FORMAT_TEXT"`
+	HTTPProxy         string  `yaml:"http-proxy" env:"HTTP_PROXY"`
 	APIs              APIs    `yaml:"apis"`
 	API               string
 	Models            map[string]Model
@@ -174,6 +176,7 @@ func newConfig() (Config, error) {
 
 	flag.StringVarP(&c.Model, "model", "m", c.Model, help["model"])
 	flag.StringVarP(&c.API, "api", "a", c.API, help["api"])
+	flag.StringVarP(&c.HTTPProxy, "http-proxy", "x", c.HTTPProxy, help["http-proxy"])
 	flag.BoolVarP(&c.Format, "format", "f", c.Format, help["format"])
 	flag.IntVarP(&c.IncludePrompt, "prompt", "P", c.IncludePrompt, help["prompt"])
 	flag.BoolVarP(&c.IncludePromptArgs, "prompt-args", "p", c.IncludePromptArgs, help["prompt-args"])

--- a/mods.go
+++ b/mods.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"math"
 	"net/http"
+	"net/url"
 	"os"
 	"strings"
 	"time"
@@ -283,6 +284,15 @@ func (m *Mods) startCompletionCmd(content string) tea.Cmd {
 			if api.BaseURL != "" {
 				ccfg.BaseURL = api.BaseURL
 			}
+		}
+
+		if cfg.HTTPProxy != "" {
+			proxyURL, err := url.Parse(cfg.HTTPProxy)
+			if err != nil {
+				return modsError{err, "There was an error parsing your proxy URL."}
+			}
+			httpClient := &http.Client{Transport: &http.Transport{Proxy: http.ProxyURL(proxyURL)}}
+			ccfg.HTTPClient = httpClient
 		}
 
 		client := openai.NewClientWithConfig(ccfg)


### PR DESCRIPTION
Various LLM model services may require an HTTP proxy for access. Adding proxy configuration options can avoid the hassle of manually configuring environment variables every time they are used.

If the `HTTPProxy` field is set in the configuration, create an `http.Client` with the specified proxy URL and use it in the `openai.NewClientWithConfig` function.