### PR TITLE
feat: `ENVIRONMENT_PRG` proposal

### DIFF
--- a/mods.go
+++ b/mods.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"os/exec"
 	"strings"
 	"time"
 	"unicode"
@@ -331,6 +332,17 @@ func (m *Mods) startCompletionCmd(content string) tea.Cmd {
 		switch mod.API {
 		case "openai":
 			if key == "" {
+				prg := os.Getenv("OPENAI_API_KEY_PRG")
+
+				if prg != "" {
+					out, err := exec.Command(prg).Output()
+
+					if err == nil {
+						key = string(out[:])
+					}
+				}
+			}
+			if key == "" {
 				key = os.Getenv("OPENAI_API_KEY")
 			}
 			if key == "" {
@@ -344,6 +356,17 @@ func (m *Mods) startCompletionCmd(content string) tea.Cmd {
 				ccfg.BaseURL = api.BaseURL
 			}
 		case "azure", "azure-ad":
+			if key == "" {
+				prg := os.Getenv("AZURE_OPENAI_KEY_PRG")
+
+				if prg != "" {
+					out, err := exec.Command(prg).Output()
+
+					if err == nil {
+						key = string(out[:])
+					}
+				}
+			}
 			if key == "" {
 				key = os.Getenv("AZURE_OPENAI_KEY")
 			}


### PR DESCRIPTION
Problem:  Environment variables are insecure.
Solution: Add `_PRG` versions of variables.

```
export OPENAI_API_KEY=plainkey # plain text
export OPENAI_API_KEY_PRG='pass openapi/chatgpt' # key from program

export AZURE_OPENAI_KEY=ABCD # insecure
export AZURE_OPENAI_KEY_PRG='pass openapi/azure' # secure

```

Related:

- [Tokens in ENV vars is insecure (ChatGPT agrees) #85](https://github.com/charmbracelet/mods/issues/85)