### PR TITLE
feat: --continue-last

### DIFF
--- a/config.go
+++ b/config.go
@@ -39,6 +39,7 @@ var help = map[string]string{
 	"settings":        "Open settings in your $EDITOR.",
 	"reset-settings":  "Reset settings to the defaults, your old settings file will be backed up.",
 	"continue":        "Continue from the last response or a given save name.",
+	"continue-last":   "Continue from the last response.",
 	"no-cache":        "Disables caching of the prompt/response.",
 	"save":            "Saves the current conversation with the given name.",
 	"list":            "Lists saved conversations.",
@@ -108,6 +109,7 @@ type Config struct {
 	Version           bool
 	Settings          bool
 	SettingsPath      string
+	ContinueLast      bool
 	Continue          string
 	Save              string
 	Show              string
@@ -192,6 +194,7 @@ func newConfig() (Config, error) {
 	flag.BoolVarP(&c.ShowHelp, "help", "h", false, help["help"])
 	flag.BoolVarP(&c.Version, "version", "v", false, help["version"])
 	flag.StringVarP(&c.Continue, "continue", "c", "", help["continue"])
+	flag.BoolVarP(&c.ContinueLast, "continue-last", "C", false, help["continue-last"])
 	flag.BoolVarP(&c.List, "list", "l", c.List, help["list"])
 	flag.IntVar(&c.MaxRetries, "max-retries", c.MaxRetries, help["max-retries"])
 	flag.BoolVar(&c.NoLimit, "no-limit", c.NoLimit, help["no-limit"])

--- a/mods_test.go
+++ b/mods_test.go
@@ -50,6 +50,7 @@ func TestFindCacheOpsDetails(t *testing.T) {
 		msg := mods.findCacheOpsDetails()()
 		dets := msg.(cacheDetailsMsg)
 		require.Equal(t, id, dets.ReadID)
+		require.Equal(t, id, dets.WriteID)
 	})
 
 	t.Run("continue title", func(t *testing.T) {
@@ -60,9 +61,22 @@ func TestFindCacheOpsDetails(t *testing.T) {
 		msg := mods.findCacheOpsDetails()()
 		dets := msg.(cacheDetailsMsg)
 		require.Equal(t, id, dets.ReadID)
+		require.Equal(t, id, dets.WriteID)
 	})
 
-	t.Run("continue latest", func(t *testing.T) {
+	t.Run("continue last", func(t *testing.T) {
+		mods := newMods(t)
+		id := newConversationID()
+		require.NoError(t, mods.db.Save(id, "message 1"))
+		mods.Config.ContinueLast = true
+		msg := mods.findCacheOpsDetails()()
+		dets := msg.(cacheDetailsMsg)
+		require.Equal(t, id, dets.ReadID)
+		require.Equal(t, id, dets.WriteID)
+		require.Empty(t, dets.Title)
+	})
+
+	t.Run("continue last with name", func(t *testing.T) {
 		mods := newMods(t)
 		id := newConversationID()
 		require.NoError(t, mods.db.Save(id, "message 1"))
@@ -72,6 +86,7 @@ func TestFindCacheOpsDetails(t *testing.T) {
 		require.Equal(t, id, dets.ReadID)
 		require.Equal(t, "message 2", dets.Title)
 		require.NotEmpty(t, dets.WriteID)
+		require.Equal(t, id, dets.WriteID)
 	})
 
 	t.Run("write", func(t *testing.T) {

--- a/spec.md
+++ b/spec.md
@@ -56,6 +56,13 @@ mods 'first 2 primes'
 mods --continue='primes as json' 'format as json'
 ```
 
+### Untitled continue latest
+
+```bash
+mods 'first 2 primes'
+mods --continue-last 'format as json'
+```
+
 ### Continue from specific conversation, save with a new title
 
 ```bash


### PR DESCRIPTION
added `--continue-last` (or `-C`) to continue the previous conversation without providing a save title

also fixed the behavior of `--continue=id` and `--continue=title` to actually update the previous conversation instead of creating a new one (unless `--save=name` is specified)