### PR TITLE
fix: --list should print list to stdout

### DIFF
--- a/main.go
+++ b/main.go
@@ -328,6 +328,7 @@ func deleteConversation(mods *Mods) {
 }
 
 func listConversations(mods *Mods) {
+	styles := makeStyles(stdoutRenderer)
 	conversations, err := db.List()
 	if err != nil {
 		exitError(mods, err, "Couldn't list saves.")
@@ -345,13 +346,17 @@ func listConversations(mods *Mods) {
 			"("+fmt.Sprint(len(conversations))+")",
 		),
 	)
+	format := "%s %s\n"
+	if isOutputTTY() {
+		format = styles.Comment.Render("•") + " %s %s\n"
+	}
 	for _, conversation := range conversations {
-		fmt.Fprintf(os.Stderr, "%s %s %s\n",
-			mods.Styles.Comment.Render("•"),
+		fmt.Fprintf(os.Stdout, format,
 			conversation.ID[:sha1short],
-			mods.Styles.Comment.Render(conversation.Title),
+			styles.Comment.Render(conversation.Title),
 		)
 	}
+
 	exit(mods, 0)
 }
 


### PR DESCRIPTION
outputting the list to stdout allows to easily pipe it into something else (e.g. grep to search).

Not sure what to do with the `Saved conversations` header though... I feel like we can probably remove it 🤔 