### PR TITLE
Document `scoop` Windows installation option

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,9 @@ You can define more LocalAI models and endpoints with `mods --settings`.
 # macOS or Linux
 brew install charmbracelet/tap/mods
 
+# Windows
+scoop install mods
+
 # Arch Linux (btw)
 yay -S mods
 


### PR DESCRIPTION
`mods` installation manifest has been added to [Scoop](https://github.com/ScoopInstaller/Scoop#what-does-scoop-do). See ScoopInstaller/Main#5002.

It is now possible to install/update the latest `mods` version on Windows using
```bash
scoop install mods
```