### PR TITLE
fix: render final result

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/adrg/xdg v0.4.0
 	github.com/caarlos0/env/v9 v9.0.0
 	github.com/charmbracelet/bubbles v0.16.1
-	github.com/charmbracelet/bubbletea v0.24.3-0.20230809191442-6a459f3bfe5e
+	github.com/charmbracelet/bubbletea v0.24.3-0.20230906172442-d55cfec13eae
 	github.com/charmbracelet/glamour v0.6.0
 	github.com/charmbracelet/glow v1.5.1
 	github.com/charmbracelet/lipgloss v0.8.0

--- a/go.sum
+++ b/go.sum
@@ -228,8 +228,8 @@ github.com/charmbracelet/bubbles v0.16.1/go.mod h1:2QCp9LFlEsBQMvIYERr7Ww2H2bA7x
 github.com/charmbracelet/bubbletea v0.12.2/go.mod h1:3gZkYELUOiEUOp0bTInkxguucy/xRbGSOcbMs1geLxg=
 github.com/charmbracelet/bubbletea v0.23.1/go.mod h1:JAfGK/3/pPKHTnAS8JIE2u9f61BjWTQY57RbT25aMXU=
 github.com/charmbracelet/bubbletea v0.23.2/go.mod h1:FaP3WUivcTM0xOKNmhciz60M6I+weYLF76mr1JyI7sM=
-github.com/charmbracelet/bubbletea v0.24.3-0.20230809191442-6a459f3bfe5e h1:sW0kFb025Yk/lbu/1LZSEbKLC6MHs44r1NcnUuSIn3g=
-github.com/charmbracelet/bubbletea v0.24.3-0.20230809191442-6a459f3bfe5e/go.mod h1:EN3QDR1T5ZdWmdfDzYcqOCAps45+QIJbLOBxmVNWNNg=
+github.com/charmbracelet/bubbletea v0.24.3-0.20230906172442-d55cfec13eae h1:RL1X3VtNcWduAE7r8+Gn7PfFMkALB4LR7JG/ackhawA=
+github.com/charmbracelet/bubbletea v0.24.3-0.20230906172442-d55cfec13eae/go.mod h1:EN3QDR1T5ZdWmdfDzYcqOCAps45+QIJbLOBxmVNWNNg=
 github.com/charmbracelet/charm v0.8.7/go.mod h1:ApJYwJljEjODkOYJgFDzbUqztLrCWQct9zyPD+xcVr4=
 github.com/charmbracelet/glamour v0.6.0 h1:wi8fse3Y7nfcabbbDuwolqTqMQPMnVPeZhDM273bISc=
 github.com/charmbracelet/glamour v0.6.0/go.mod h1:taqWV4swIMMbWALc0m7AfE9JkPSU8om2538k9ITBxOc=

--- a/main.go
+++ b/main.go
@@ -73,7 +73,6 @@ var (
 			stderr := cmd.ErrOrStderr()
 			opts := []tea.ProgramOption{
 				tea.WithOutput(stderrRenderer().Output()),
-				// tea.WithoutEmptyRenders(),
 			}
 
 			if !isInputTTY() {

--- a/main.go
+++ b/main.go
@@ -73,7 +73,7 @@ var (
 			stderr := cmd.ErrOrStderr()
 			opts := []tea.ProgramOption{
 				tea.WithOutput(stderrRenderer().Output()),
-				tea.WithoutEmptyRenders(),
+				// tea.WithoutEmptyRenders(),
 			}
 
 			if !isInputTTY() {
@@ -121,16 +121,25 @@ var (
 				return cmd.Usage()
 			}
 
-			if config.Show != "" {
-				return nil
-			}
-
 			if config.List {
 				return listConversations()
 			}
 
 			if config.Delete != "" {
 				return deleteConversation()
+			}
+
+			if isOutputTTY() {
+				switch {
+				case mods.glamOutput != "":
+					fmt.Print(mods.glamOutput)
+				case mods.Output != "":
+					fmt.Print(mods.Output)
+				}
+			}
+
+			if config.Show != "" {
+				return nil
 			}
 
 			if config.cacheWriteToID != "" {

--- a/mods.go
+++ b/mods.go
@@ -233,19 +233,10 @@ func (m *Mods) View() string {
 		m.content = []string{}
 		m.contentMutex.Unlock()
 	case doneState:
-		if m.Config.Glamour {
-			if m.viewportNeeded() {
-				return m.glamViewport.View()
-			}
-			// We don't need the viewport yet.
-			return m.glamOutput + "\n"
+		if !isOutputTTY() {
+			fmt.Printf("\n")
 		}
-
-		if isOutputTTY() {
-			return m.Output + "\n"
-		}
-
-		fmt.Print("\n")
+		return ""
 	}
 	return ""
 }


### PR DESCRIPTION
This will make mods behave a bit differently when the output is a TTY:

- it'll clear the view (returning `""`) in the end
- then print the content to stdout outside bubbletea loop 

If the output is not a TTY (i.e. `| some_other_prog`), it'll stream as before and do nothing else.