### PR TITLE
feat: adds support to api key on settings mods.yaml

### DIFF
--- a/config.go
+++ b/config.go
@@ -60,6 +60,7 @@ type Model struct {
 // API represents an API endpoint and its models.
 type API struct {
 	Name      string
+	APIKey    string           `yaml:"api-key"`
 	APIKeyEnv string           `yaml:"api-key-env"`
 	BaseURL   string           `yaml:"base-url"`
 	Models    map[string]Model `yaml:"models"`

--- a/config_template.go
+++ b/config_template.go
@@ -35,6 +35,7 @@ max-input-chars: 12250
 apis:
   openai:
     base-url: https://api.openai.com/v1
+	api-key: 
     api-key-env: OPENAI_API_KEY
     models:
       gpt-4:
@@ -69,6 +70,7 @@ apis:
     # Set to 'azure-ad' to use Active Directory
     # Azure OpenAI setup: https://learn.microsoft.com/en-us/azure/cognitive-services/openai/how-to/create-resource
     base-url: https://YOUR_RESOURCE_NAME.openai.azure.com
+    api-key: 
     api-key-env: AZURE_OPENAI_KEY
     models:
       gpt-4:

--- a/config_template.go
+++ b/config_template.go
@@ -35,7 +35,7 @@ max-input-chars: 12250
 apis:
   openai:
     base-url: https://api.openai.com/v1
-	api-key: 
+    api-key: 
     api-key-env: OPENAI_API_KEY
     models:
       gpt-4:

--- a/mods.go
+++ b/mods.go
@@ -308,7 +308,7 @@ func (m *Mods) startCompletionCmd(content string) tea.Cmd {
 			}
 		}
 
-		// tries to use API key value; otherwise searches for env variable
+		// Uses API key value if found; otherwise searches for env variable.
 		key = api.APIKey
 		if key == "" && api.APIKeyEnv != "" {
 			key = os.Getenv(api.APIKeyEnv)

--- a/mods.go
+++ b/mods.go
@@ -20,7 +20,7 @@ import (
 	"github.com/charmbracelet/glamour"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/x/exp/ordered"
-	"github.com/sashabaranov/go-openai"
+	openai "github.com/sashabaranov/go-openai"
 )
 
 type state int

--- a/mods.go
+++ b/mods.go
@@ -20,7 +20,7 @@ import (
 	"github.com/charmbracelet/glamour"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/x/exp/ordered"
-	openai "github.com/sashabaranov/go-openai"
+	"github.com/sashabaranov/go-openai"
 )
 
 type state int
@@ -307,7 +307,10 @@ func (m *Mods) startCompletionCmd(content string) tea.Cmd {
 				),
 			}
 		}
-		if api.APIKeyEnv != "" {
+
+		// tries to use API key value; otherwise searches for env variable
+		key = api.APIKey
+		if key == "" && api.APIKeyEnv != "" {
 			key = os.Getenv(api.APIKeyEnv)
 		}
 
@@ -319,7 +322,7 @@ func (m *Mods) startCompletionCmd(content string) tea.Cmd {
 			if key == "" {
 				return modsError{
 					reason: fmt.Sprintf(
-						"%s environment variable is required.",
+						"%[1]s required; set environment variable %[1]s or update mods.yaml through --settings.",
 						m.Styles.InlineCode.Render("OPENAI_API_KEY"),
 					),
 					err: fmt.Errorf(
@@ -339,7 +342,7 @@ func (m *Mods) startCompletionCmd(content string) tea.Cmd {
 			if key == "" {
 				return modsError{
 					reason: fmt.Sprintf(
-						"%s environment variable is required.",
+						"%[1]s required; set environment variable %[1]s or update mods.yaml through --settings.",
 						m.Styles.InlineCode.Render("AZURE_OPENAI_KEY"),
 					),
 					err: fmt.Errorf(


### PR DESCRIPTION
Partially addresses #117 `specify api key directly (instead of referencing env var)`.

This PR adds the functionality of setting the API key directly on the settings `mods.yaml` file. If no value is set (which is the default setting), it falls through to the current behavior (env var check and err message if unset). 

The error message was also updated to reflect these changes. Message's up to changes if requested!

No tests were updated as no tests regarding this particular flow were found.