### PR TITLE
feat: have --quiet supress all stderr messages for success

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,8 @@ Your desired level of fanciness.
 
 `-q`, `--quiet`, `MODS_QUIET`
 
-Output nothing to standard err.
+Only output errors to standard err. Hides the spinner and success messages
+that would go to standard err.
 
 #### Reset Settings
 

--- a/config.go
+++ b/config.go
@@ -27,7 +27,7 @@ var help = map[string]string{
 	"prompt":          "Include the prompt from the arguments and stdin, truncate stdin to specified number of lines.",
 	"prompt-args":     "Include the prompt from the arguments in the response.",
 	"raw":             "Render output as raw text when connected to a TTY.",
-	"quiet":           "Quiet mode (hide the spinner while loading).",
+	"quiet":           "Quiet mode (hide the spinner while loading and stderr messages for success).",
 	"help":            "Show help and exit.",
 	"version":         "Show version and exit.",
 	"max-retries":     "Maximum number of times to retry API calls.",

--- a/main.go
+++ b/main.go
@@ -106,7 +106,9 @@ var (
 					)}
 				}
 
-				fmt.Fprintln(stderr, "Wrote config file to:", config.SettingsPath)
+				if !config.Quiet {
+					fmt.Fprintln(stderr, "Wrote config file to:", config.SettingsPath)
+				}
 				return nil
 			}
 
@@ -308,12 +310,14 @@ func resetSettings() error {
 	if err != nil {
 		return modsError{err, "Couldn't write new config file."}
 	}
-	fmt.Fprintln(os.Stderr, "\nSettings restored to defaults!")
-	fmt.Fprintf(os.Stderr,
-		"\n  %s %s\n\n",
-		stderrStyles().Comment.Render("Your old settings have been saved to:"),
-		stderrStyles().Link.Render(config.SettingsPath+".bak"),
-	)
+	if !config.Quiet {
+		fmt.Fprintln(os.Stderr, "\nSettings restored to defaults!")
+		fmt.Fprintf(os.Stderr,
+			"\n  %s %s\n\n",
+			stderrStyles().Comment.Render("Your old settings have been saved to:"),
+			stderrStyles().Link.Render(config.SettingsPath+".bak"),
+		)
+	}
 	return nil
 }
 
@@ -331,7 +335,9 @@ func deleteConversation() error {
 		return modsError{err, "Couldn't delete conversation."}
 	}
 
-	fmt.Fprintln(os.Stderr, "Conversation deleted:", convo.ID[:sha1minLen])
+	if !config.Quiet {
+		fmt.Fprintln(os.Stderr, "Conversation deleted:", convo.ID[:sha1minLen])
+	}
 	return nil
 }
 
@@ -380,12 +386,14 @@ func listConversations() error {
 
 func saveConversation(mods *Mods) error {
 	if config.NoCache {
-		fmt.Fprintf(
-			os.Stderr,
-			"\nConversation was not saved because %s or %s is set.\n",
-			stderrStyles().InlineCode.Render("--no-cache"),
-			stderrStyles().InlineCode.Render("NO_CACHE"),
-		)
+		if !config.Quiet {
+			fmt.Fprintf(
+				os.Stderr,
+				"\nConversation was not saved because %s or %s is set.\n",
+				stderrStyles().InlineCode.Render("--no-cache"),
+				stderrStyles().InlineCode.Render("NO_CACHE"),
+			)
+		}
 		return nil
 	}
 
@@ -415,11 +423,13 @@ func saveConversation(mods *Mods) error {
 		)}
 	}
 
-	fmt.Fprintln(
-		os.Stderr,
-		"\nConversation saved:",
-		stderrStyles().InlineCode.Render(config.cacheWriteToID[:sha1short]),
-		stderrStyles().Comment.Render(title),
-	)
+	if !config.Quiet {
+		fmt.Fprintln(
+			os.Stderr,
+			"\nConversation saved:",
+			stderrStyles().InlineCode.Render(config.cacheWriteToID[:sha1short]),
+			stderrStyles().Comment.Render(title),
+		)
+	}
 	return nil
 }


### PR DESCRIPTION
Before this commit, according to the README, `--quiet` should supress all stderr output, which was incorrect. It did what the help says: supress only the spinner.

This commit makes `--quiet` supress all "superflous" stderr ouput, meaning both the spinner and messages that confirm an operation was carried out successfully like "Conversation saved...".

Rationale: for scriptability, it would be nice to be able to supress non-error stderr messages without losing the ability to see the error when something actually goes wrong.

Maybe this isn't the way to do it though, and there should be options for `--no-spinner`, `--quiet` (supress all stderr) and `--shy` (what this commit implements).