### PR TITLE
fix: improve --continue

### DIFF
--- a/mods.go
+++ b/mods.go
@@ -505,13 +505,6 @@ func (m *Mods) findCacheOpsDetails() tea.Cmd {
 		writeID := ordered.First(m.Config.Title, m.Config.Continue)
 		title := writeID
 
-		if continueLast && m.Config.Prefix == "" {
-			return modsError{
-				err:    fmt.Errorf("Missing prompt"),
-				reason: "You must specify a prompt.",
-			}
-		}
-
 		if readID != "" || continueLast || m.Config.ShowLast {
 			found, err := m.findReadID(readID)
 			if err != nil {

--- a/mods_test.go
+++ b/mods_test.go
@@ -61,9 +61,10 @@ func TestFindCacheOpsDetails(t *testing.T) {
 		require.NoError(t, mods.db.Save(id, "message 1"))
 		mods.Config.ContinueLast = true
 		msg := mods.findCacheOpsDetails()()
-		err := msg.(modsError)
-		require.Error(t, err.err)
-		require.Equal(t, "You must specify a prompt.", err.reason)
+		dets := msg.(cacheDetailsMsg)
+		require.Equal(t, id, dets.ReadID)
+		require.Equal(t, id, dets.WriteID)
+		require.Empty(t, dets.Title)
 	})
 
 	t.Run("continue title", func(t *testing.T) {


### PR DESCRIPTION
If you run `mods` without any args or input, it'll print the help. If you run `mods` with either a prompt or piping something from stdin, it uses that as a prompt.

`mods -C` was requiring a prompt even when it was provided via stdin. This removes that check, so it works the same as `mods` without the `-C` flag now.

closes #132