### PR TITLE
fix: drop extra leading newline in config template

### DIFF
--- a/config_template.go
+++ b/config_template.go
@@ -1,7 +1,6 @@
 package main
 
-const configTemplate = `
-# {{ index .Help "model" }}
+const configTemplate = `# {{ index .Help "model" }}
 default-model: gpt-4
 # {{ index .Help "format-text" }}
 format-text: Format the response as markdown without enclosing backticks.


### PR DESCRIPTION
This revision strips the extra leading newline in the config template:

<img width="689" alt="image" src="https://github.com/charmbracelet/mods/assets/25087/aa9b9db8-cef5-415d-be0a-3c72eb4e40df">
