### PR TITLE
feat: ask user for prompt

### DIFF
--- a/main.go
+++ b/main.go
@@ -80,6 +80,8 @@ var (
 
 			if !isInputTTY() {
 				opts = append(opts, tea.WithInput(nil))
+				fmt.Printf("This program is not running in a terminal.\n\n")
+				return cmd.Usage()
 			}
 
 			mods := newMods(stderrRenderer(), &config, db, cache)
@@ -125,8 +127,12 @@ var (
 				return resetSettings()
 			}
 
-			if config.ShowHelp || (mods.Input == "" &&
-				config.Prefix == "" &&
+			if mods.Input == "" {
+				fmt.Printf("You haven't provided an input prompt.\n\n")
+				return nil
+			}
+
+			if config.ShowHelp || (config.Prefix == "" &&
 				config.Show == "" &&
 				!config.ShowLast &&
 				config.Delete == "" &&


### PR DESCRIPTION
This Pull Request:

- Add support to prompts the user for input if `mods` is run in a terminal without receiving an input argument.
- For non-terminal usage, modified the program to show an error message along with the usage details.

closes #160 