### PR TITLE
feat: ask user for prompt

### DIFF
--- a/main.go
+++ b/main.go
@@ -80,6 +80,8 @@ var (
 
 			if !isInputTTY() {
 				opts = append(opts, tea.WithInput(nil))
+				fmt.Printf("This program is not running in a terminal.\n\n")
+				return cmd.Usage()
 			}
 
 			mods := newMods(stderrRenderer(), &config, db, cache)
@@ -125,12 +127,15 @@ var (
 				return resetSettings()
 			}
 
-			if config.ShowHelp || (mods.Input == "" &&
-				config.Prefix == "" &&
+			if config.ShowHelp || (config.Prefix == "" &&
 				config.Show == "" &&
 				!config.ShowLast &&
 				config.Delete == "" &&
 				!config.List) {
+				if mods.Input == "" {
+					fmt.Printf("You haven't provided an input prompt.\n\n")
+					return nil
+				}
 				//nolint: wrapcheck
 				return cmd.Usage()
 			}

--- a/main.go
+++ b/main.go
@@ -127,7 +127,8 @@ var (
 				return resetSettings()
 			}
 
-			if config.ShowHelp || (config.Prefix == "" &&
+			if config.ShowHelp || (mods.Input == "" &&
+				config.Prefix == "" &&
 				config.Show == "" &&
 				!config.ShowLast &&
 				config.Delete == "" &&


### PR DESCRIPTION
### Description:

This Pull Request focuses on facilitating improved user interaction by introducing features to manage both terminal and non-terminal usages.
  
Specifically:

- Support is now added to prompt the user for input when `mods` is executed in a terminal without any input arguments.
- When it comes to non-terminal usage, the logic of the tool has been modified to display an error message along with usage details.

### Evidences:
1. Scenario: Execution of 'mods' without any input argument
<img width="714" alt="Screenshot 2023-12-30 at 12 59 45" src="https://github.com/charmbracelet/mods/assets/65210800/d866420d-b5e4-47a7-9c38-78b70e80e8d5">

2. Scenario: Execution of 'mods' with input prompt
<img width="713" alt="Screenshot 2023-12-30 at 13 00 54" src="https://github.com/charmbracelet/mods/assets/65210800/40578dfd-b8b5-429c-82f1-63cce0f14d33">

3. Scenario: Non-terminal usage of 'mods'
<img width="717" alt="Screenshot 2023-12-30 at 13 00 47" src="https://github.com/charmbracelet/mods/assets/65210800/95476699-d43d-43f2-b0f2-2296e88f07c1">

### This PR provides a solution for the issue:
closes https://github.com/charmbracelet/mods/issues/160