### PR TITLE
fix: do not append formatting prompt to db save title

### DIFF
--- a/mods.go
+++ b/mods.go
@@ -377,7 +377,7 @@ func (m *Mods) startCompletionCmd(content string) tea.Cmd {
 		m.cancelRequest = cancel
 		prefix := cfg.Prefix
 		if cfg.Format {
-			prefix = fmt.Sprintf("%s %s", prefix, cfg.FormatText)
+			prefix = fmt.Sprintf("%s\n%s", prefix, cfg.FormatText)
 		}
 		if prefix != "" {
 			content = strings.TrimSpace(prefix + "\n\n" + content)


### PR DESCRIPTION
if the user don't set a title to the convo, it'll use the first line of the prompt.

adding a new line between the prompt and the format text makes sense, as before it could generate strings like `tell a joke format in markdown`.

closes #182