### PR TITLE
fix: handle missing prompt

### DIFF
--- a/flag.go
+++ b/flag.go
@@ -69,6 +69,7 @@ type durationFlag time.Duration
 func (d *durationFlag) Set(s string) error {
 	v, err := duration.Parse(s)
 	*d = durationFlag(v)
+	//nolint: wrapcheck
 	return err
 }
 

--- a/main.go
+++ b/main.go
@@ -70,7 +70,7 @@ var (
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			config.Prefix = strings.Join(args, " ")
+			config.Prefix = removeWhitespace(strings.Join(args, " "))
 
 			stdin := cmd.InOrStdin()
 			stdout := cmd.OutOrStdout()

--- a/main.go
+++ b/main.go
@@ -383,12 +383,16 @@ func deleteConversationOlderThan() error {
 		printList(conversations)
 		fmt.Fprintln(os.Stderr)
 		var confirm bool
+		km := huh.NewDefaultKeyMap()
+		km.Confirm.Next.SetHelp("", "")
+		km.Confirm.Prev.SetEnabled(false)
 		if err := huh.NewForm(
 			huh.NewGroup(
 				huh.NewConfirm().
 					Title(fmt.Sprintf("Delete conversations older than %s?", config.DeleteOlderThan)).
 					Description(fmt.Sprintf("This will delete all the %d conversations listed above.", len(conversations))).
-					Value(&confirm),
+					Value(&confirm).
+					WithKeyMap(km),
 			),
 		).Run(); err != nil {
 			return modsError{err, "Couldn't delete old conversations."}

--- a/main.go
+++ b/main.go
@@ -133,6 +133,17 @@ var (
 				config.Delete == "" &&
 				config.DeleteOlderThan == 0 &&
 				!config.List) {
+
+				if mods.Input == "" && isInputTTY() {
+					return modsError{
+						reason: "You haven't provided any prompt input.",
+						err: newUserErrorf(
+							"You can give your prompt as arguments and/or pipe it from STDIN.\nExample:" +
+								stdoutStyles().InlineCode.Render("mods [prompt]"),
+						),
+					}
+				}
+
 				//nolint: wrapcheck
 				return cmd.Usage()
 			}

--- a/main.go
+++ b/main.go
@@ -87,7 +87,7 @@ var (
 				if err := huh.Run(
 					huh.NewText().
 						Title(fmt.Sprintf("Write a prompt for %s:", config.Model)).
-						Lines(4).
+						Lines(4). //nolint: gomnd
 						Value(&config.Prefix),
 				); err != nil {
 					return modsError{
@@ -111,6 +111,7 @@ var (
 
 			if config.Dirs {
 				fmt.Printf("Configuration: %s\n", filepath.Dir(config.SettingsPath))
+				//nolint: gomnd
 				fmt.Printf("%*sCache: %s\n", 8, " ", filepath.Dir(config.CachePath))
 				return nil
 			}
@@ -118,7 +119,10 @@ var (
 			if config.Settings {
 				c, err := editor.Cmd("mods", config.SettingsPath)
 				if err != nil {
-					return err
+					return modsError{
+						err:    err,
+						reason: "Could not edit your settings file.",
+					}
 				}
 				c.Stdin = stdin
 				c.Stdout = stdout

--- a/main.go
+++ b/main.go
@@ -84,17 +84,12 @@ var (
 			}
 
 			if isNoArgs() && isInputTTY() {
-				km := huh.NewDefaultKeyMap()
-				km.Text.Prev.SetEnabled(false)
-				km.Text.Next.SetHelp("enter", "submit")
-				if err := huh.NewForm(
-					huh.NewGroup(
-						huh.NewText().
-							Title(fmt.Sprintf("Write a prompt for %s:", config.Model)).
-							Lines(4).
-							Value(&config.Prefix),
-					),
-				).WithKeyMap(km).Run(); err != nil {
+				if err := huh.Run(
+					huh.NewText().
+						Title(fmt.Sprintf("Write a prompt for %s:", config.Model)).
+						Lines(4).
+						Value(&config.Prefix),
+				); err != nil {
 					return modsError{
 						err:    err,
 						reason: "No prompt provided and failed to ask for one.",
@@ -382,17 +377,12 @@ func deleteConversationOlderThan() error {
 		printList(conversations)
 		fmt.Fprintln(os.Stderr)
 		var confirm bool
-		km := huh.NewDefaultKeyMap()
-		km.Confirm.Next.SetHelp("enter", "confirm")
-		km.Confirm.Prev.SetEnabled(false)
-		if err := huh.NewForm(
-			huh.NewGroup(
-				huh.NewConfirm().
-					Title(fmt.Sprintf("Delete conversations older than %s?", config.DeleteOlderThan)).
-					Description(fmt.Sprintf("This will delete all the %d conversations listed above.", len(conversations))).
-					Value(&confirm),
-			),
-		).WithKeyMap(km).Run(); err != nil {
+		if err := huh.Run(
+			huh.NewConfirm().
+				Title(fmt.Sprintf("Delete conversations older than %s?", config.DeleteOlderThan)).
+				Description(fmt.Sprintf("This will delete all the %d conversations listed above.", len(conversations))).
+				Value(&confirm),
+		); err != nil {
 			return modsError{err, "Couldn't delete old conversations."}
 		}
 		if !confirm {

--- a/main.go
+++ b/main.go
@@ -92,10 +92,9 @@ var (
 						huh.NewText().
 							Title(fmt.Sprintf("Write a prompt for %s:", config.Model)).
 							Lines(4).
-							Value(&config.Prefix).
-							WithKeyMap(km),
+							Value(&config.Prefix),
 					),
-				).Run(); err != nil {
+				).WithKeyMap(km).Run(); err != nil {
 					return modsError{
 						err:    err,
 						reason: "No prompt provided and failed to ask for one.",
@@ -384,17 +383,16 @@ func deleteConversationOlderThan() error {
 		fmt.Fprintln(os.Stderr)
 		var confirm bool
 		km := huh.NewDefaultKeyMap()
-		km.Confirm.Next.SetHelp("", "")
+		km.Confirm.Next.SetHelp("enter", "confirm")
 		km.Confirm.Prev.SetEnabled(false)
 		if err := huh.NewForm(
 			huh.NewGroup(
 				huh.NewConfirm().
 					Title(fmt.Sprintf("Delete conversations older than %s?", config.DeleteOlderThan)).
 					Description(fmt.Sprintf("This will delete all the %d conversations listed above.", len(conversations))).
-					Value(&confirm).
-					WithKeyMap(km),
+					Value(&confirm),
 			),
-		).Run(); err != nil {
+		).WithKeyMap(km).Run(); err != nil {
 			return modsError{err, "Couldn't delete old conversations."}
 		}
 		if !confirm {

--- a/main.go
+++ b/main.go
@@ -83,7 +83,7 @@ var (
 				opts = append(opts, tea.WithInput(nil))
 			}
 
-			if config.Prefix == "" && isInputTTY() {
+			if isNoArgs() && isInputTTY() {
 				km := huh.NewDefaultKeyMap()
 				km.Text.Prev.SetEnabled(false)
 				km.Text.Next.SetHelp("enter", "submit")
@@ -146,22 +146,17 @@ var (
 				return resetSettings()
 			}
 
-			if config.ShowHelp || (mods.Input == "" &&
-				config.Prefix == "" &&
-				config.Show == "" &&
-				!config.ShowLast &&
-				config.Delete == "" &&
-				config.DeleteOlderThan == 0 &&
-				!config.List) {
-				if mods.Input == "" && config.Prefix == "" {
-					return modsError{
-						reason: "You haven't provided any prompt input.",
-						err: newUserErrorf(
-							"You can give your prompt as arguments and/or pipe it from STDIN.\nExample: " +
-								stdoutStyles().InlineCode.Render("mods [prompt]"),
-						),
-					}
+			if mods.Input == "" && isNoArgs() {
+				return modsError{
+					reason: "You haven't provided any prompt input.",
+					err: newUserErrorf(
+						"You can give your prompt as arguments and/or pipe it from STDIN.\nExample: " +
+							stdoutStyles().InlineCode.Render("mods [prompt]"),
+					),
 				}
+			}
+
+			if config.ShowHelp {
 				//nolint: wrapcheck
 				return cmd.Usage()
 			}
@@ -535,4 +530,14 @@ func saveConversation(mods *Mods) error {
 		)
 	}
 	return nil
+}
+
+func isNoArgs() bool {
+	return config.Prefix == "" &&
+		config.Show == "" &&
+		!config.ShowLast &&
+		config.Delete == "" &&
+		config.DeleteOlderThan == 0 &&
+		!config.ShowHelp &&
+		!config.List
 }

--- a/main.go
+++ b/main.go
@@ -84,12 +84,16 @@ var (
 			}
 
 			if config.Prefix == "" && isInputTTY() {
+				km := huh.NewDefaultKeyMap()
+				km.Text.Prev.SetEnabled(false)
+				km.Text.Next.SetHelp("enter", "submit")
 				if err := huh.NewForm(
 					huh.NewGroup(
 						huh.NewText().
 							Title(fmt.Sprintf("Write a prompt for %s:", config.Model)).
 							Lines(4).
-							Value(&config.Prefix),
+							Value(&config.Prefix).
+							WithKeyMap(km),
 					),
 				).Run(); err != nil {
 					return modsError{

--- a/main.go
+++ b/main.go
@@ -138,7 +138,7 @@ var (
 					return modsError{
 						reason: "You haven't provided any prompt input.",
 						err: newUserErrorf(
-							"You can give your prompt as arguments and/or pipe it from STDIN.\nExample:" +
+							"You can give your prompt as arguments and/or pipe it from STDIN.\nExample: " +
 								stdoutStyles().InlineCode.Render("mods [prompt]"),
 						),
 					}

--- a/main.go
+++ b/main.go
@@ -149,6 +149,15 @@ var (
 				config.Delete == "" &&
 				config.DeleteOlderThan == 0 &&
 				!config.List) {
+				if mods.Input == "" && config.Prefix == "" {
+					return modsError{
+						reason: "You haven't provided any prompt input.",
+						err: newUserErrorf(
+							"You can give your prompt as arguments and/or pipe it from STDIN.\nExample: " +
+								stdoutStyles().InlineCode.Render("mods [prompt]"),
+						),
+					}
+				}
 				//nolint: wrapcheck
 				return cmd.Usage()
 			}
@@ -493,20 +502,6 @@ func saveConversation(mods *Mods) error {
 
 	if sha1reg.MatchString(title) || title == "" {
 		title = firstLine(lastPrompt(mods.messages))
-	}
-
-	// if title is empty, it means that the user probably run something like:
-	// cat emptyfile.txt | mods
-	// so the prompt was effectively empty but we didn't know it before.
-	if title == "" {
-		// no prompt
-		return modsError{
-			reason: "You haven't provided any prompt input.",
-			err: newUserErrorf(
-				"You can give your prompt as arguments and/or pipe it from STDIN.\nExample: " +
-					stdoutStyles().InlineCode.Render("mods [prompt]"),
-			),
-		}
 	}
 
 	if err := cache.write(id, &mods.messages); err != nil {

--- a/mods.go
+++ b/mods.go
@@ -116,11 +116,7 @@ func (m *Mods) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case completionInput:
 		if msg.content != "" {
-			m.Input = msg.content
-		}
-		if strings.TrimSpace(m.Input) == "" {
-			// if the input is whitespace only, make it empty.
-			m.Input = ""
+			m.Input = removeWhitespace(msg.content)
 		}
 		if m.Input == "" && m.Config.Prefix == "" && m.Config.Show == "" && !m.Config.ShowLast {
 			return m, m.quit
@@ -611,4 +607,12 @@ func (m *Mods) appendToOutput(s string) {
 		// the bottom.
 		m.glamViewport.GotoBottom()
 	}
+}
+
+// if the input is whitespace only, make it empty.
+func removeWhitespace(s string) string {
+	if strings.TrimSpace(s) == "" {
+		return ""
+	}
+	return s
 }

--- a/mods.go
+++ b/mods.go
@@ -118,7 +118,10 @@ func (m *Mods) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if msg.content != "" {
 			m.Input = msg.content
 		}
-		if msg.content == "" && m.Config.Prefix == "" && m.Config.Show == "" && !m.Config.ShowLast {
+		if strings.TrimSpace(msg.content) == "" &&
+			strings.TrimSpace(m.Config.Prefix) == "" &&
+			m.Config.Show == "" &&
+			!m.Config.ShowLast {
 			return m, m.quit
 		}
 

--- a/mods.go
+++ b/mods.go
@@ -118,10 +118,11 @@ func (m *Mods) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if msg.content != "" {
 			m.Input = msg.content
 		}
-		if strings.TrimSpace(msg.content) == "" &&
-			strings.TrimSpace(m.Config.Prefix) == "" &&
-			m.Config.Show == "" &&
-			!m.Config.ShowLast {
+		if strings.TrimSpace(m.Input) == "" {
+			// if the input is whitespace only, make it empty.
+			m.Input = ""
+		}
+		if m.Input == "" && m.Config.Prefix == "" && m.Config.Show == "" && !m.Config.ShowLast {
 			return m, m.quit
 		}
 


### PR DESCRIPTION
This PR changes #179 a bit:

- only errors if input is not a TTY (reading from STDIN) and the Args+STDIN is empty
- if input is TTY, ask for user input using huh
- fail-fast if user input is whitespace only (e.g. piping an empty file)
- a side-effect of this is that now it'll only show the help if run with `--help`/`-h`

supersedes #179 
closes #179
closes #160