### PR TITLE
feat: support json

### DIFF
--- a/config.go
+++ b/config.go
@@ -23,6 +23,11 @@ import (
 //go:embed config_template.yml
 var configTemplate string
 
+const (
+	defaultMarkdownFormatText = "Format the response as markdown without enclosing backticks."
+	defaultJSONFormatText     = "Format the response as json without enclosing backticks."
+)
+
 var help = map[string]string{
 	"api":               "OpenAI compatible REST API (openai, localai).",
 	"apis":              "Aliases and endpoints for OpenAI compatible REST API.",
@@ -232,7 +237,6 @@ func writeConfigFile(path string) error {
 func createConfigFile(path string) error {
 	tmpl := template.Must(template.New("config").Parse(configTemplate))
 
-	var c Config
 	f, err := os.Create(path)
 	if err != nil {
 		return modsError{err, "Could not create configuration file."}
@@ -243,13 +247,23 @@ func createConfigFile(path string) error {
 		Config Config
 		Help   map[string]string
 	}{
-		Config: c,
+		Config: defaultConfig(),
 		Help:   help,
 	}
 	if err := tmpl.Execute(f, m); err != nil {
 		return modsError{err, "Could not render template."}
 	}
 	return nil
+}
+
+func defaultConfig() Config {
+	return Config{
+		FormatAs: "markdown",
+		FormatText: FormatText{
+			"markdown": defaultMarkdownFormatText,
+			"json":     defaultJSONFormatText,
+		},
+	}
 }
 
 func useLine() string {

--- a/config.go
+++ b/config.go
@@ -88,8 +88,10 @@ func (apis *APIs) UnmarshalYAML(node *yaml.Node) error {
 	return nil
 }
 
+// FormatText is a map[format]formatting_text.
 type FormatText map[string]string
 
+// UnmarshalYAML conforms with yaml.Unmarshaler.
 func (ft *FormatText) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	var text string
 	if err := unmarshal(&text); err != nil {

--- a/config.go
+++ b/config.go
@@ -88,28 +88,48 @@ func (apis *APIs) UnmarshalYAML(node *yaml.Node) error {
 	return nil
 }
 
+type FormatText map[string]string
+
+func (ft *FormatText) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var text string
+	if err := unmarshal(&text); err != nil {
+		var formats map[string]string
+		if err := unmarshal(&formats); err != nil {
+			return err
+		}
+		*ft = (FormatText)(formats)
+		return nil
+	}
+
+	*ft = map[string]string{
+		"markdown": text,
+	}
+	return nil
+}
+
 // Config holds the main configuration and is mapped to the YAML settings file.
 type Config struct {
-	Model             string  `yaml:"default-model" env:"MODEL"`
-	Format            bool    `yaml:"format" env:"FORMAT"`
-	Raw               bool    `yaml:"raw" env:"RAW"`
-	Quiet             bool    `yaml:"quiet" env:"QUIET"`
-	MaxTokens         int     `yaml:"max-tokens" env:"MAX_TOKENS"`
-	MaxInputChars     int     `yaml:"max-input-chars" env:"MAX_INPUT_CHARS"`
-	Temperature       float32 `yaml:"temp" env:"TEMP"`
-	TopP              float32 `yaml:"topp" env:"TOPP"`
-	NoLimit           bool    `yaml:"no-limit" env:"NO_LIMIT"`
-	CachePath         string  `yaml:"cache-path" env:"CACHE_PATH"`
-	NoCache           bool    `yaml:"no-cache" env:"NO_CACHE"`
-	IncludePromptArgs bool    `yaml:"include-prompt-args" env:"INCLUDE_PROMPT_ARGS"`
-	IncludePrompt     int     `yaml:"include-prompt" env:"INCLUDE_PROMPT"`
-	MaxRetries        int     `yaml:"max-retries" env:"MAX_RETRIES"`
-	WordWrap          int     `yaml:"word-wrap" env:"WORD_WRAP"`
-	Fanciness         uint    `yaml:"fanciness" env:"FANCINESS"`
-	StatusText        string  `yaml:"status-text" env:"STATUS_TEXT"`
-	FormatText        string  `yaml:"format-text" env:"FORMAT_TEXT"`
-	HTTPProxy         string  `yaml:"http-proxy" env:"HTTP_PROXY"`
-	APIs              APIs    `yaml:"apis"`
+	Model             string     `yaml:"default-model" env:"MODEL"`
+	Format            bool       `yaml:"format" env:"FORMAT"`
+	Raw               bool       `yaml:"raw" env:"RAW"`
+	Quiet             bool       `yaml:"quiet" env:"QUIET"`
+	MaxTokens         int        `yaml:"max-tokens" env:"MAX_TOKENS"`
+	MaxInputChars     int        `yaml:"max-input-chars" env:"MAX_INPUT_CHARS"`
+	Temperature       float32    `yaml:"temp" env:"TEMP"`
+	TopP              float32    `yaml:"topp" env:"TOPP"`
+	NoLimit           bool       `yaml:"no-limit" env:"NO_LIMIT"`
+	CachePath         string     `yaml:"cache-path" env:"CACHE_PATH"`
+	NoCache           bool       `yaml:"no-cache" env:"NO_CACHE"`
+	IncludePromptArgs bool       `yaml:"include-prompt-args" env:"INCLUDE_PROMPT_ARGS"`
+	IncludePrompt     int        `yaml:"include-prompt" env:"INCLUDE_PROMPT"`
+	MaxRetries        int        `yaml:"max-retries" env:"MAX_RETRIES"`
+	WordWrap          int        `yaml:"word-wrap" env:"WORD_WRAP"`
+	Fanciness         uint       `yaml:"fanciness" env:"FANCINESS"`
+	StatusText        string     `yaml:"status-text" env:"STATUS_TEXT"`
+	FormatText        FormatText `yaml:"format-text" env:"FORMAT_TEXT"`
+	HTTPProxy         string     `yaml:"http-proxy" env:"HTTP_PROXY"`
+	APIs              APIs       `yaml:"apis"`
+	FormatAs          string
 	API               string
 	Models            map[string]Model
 	ShowHelp          bool

--- a/config_template.go
+++ b/config_template.go
@@ -3,7 +3,9 @@ package main
 const configTemplate = `# {{ index .Help "model" }}
 default-model: gpt-4
 # {{ index .Help "format-text" }}
-format-text: Format the response as markdown without enclosing backticks.
+format-text:
+  markdown: Format the response as markdown without enclosing backticks.
+  json: Format the response as json without enclosing backticks.
 # {{ index .Help "format" }}
 format: false
 # {{ index .Help "raw" }}
@@ -36,7 +38,7 @@ max-input-chars: 12250
 apis:
   openai:
     base-url: https://api.openai.com/v1
-    api-key: 
+    api-key:
     api-key-env: OPENAI_API_KEY
     models:
       gpt-4:
@@ -47,9 +49,17 @@ apis:
         aliases: ["32k"]
         max-input-chars: 98000
         fallback: gpt-4
+      gpt-4-1106-preview:
+        aliases: ["4-preview"]
+        max-input-chars: 98000
+        fallback: gpt-4
       gpt-3.5-turbo:
         aliases: ["35t"]
         max-input-chars: 12250
+        fallback: gpt-3.5
+      gpt-3.5-turbo-1106:
+        aliases: ["35t1106"]
+        max-input-chars: 44500
         fallback: gpt-3.5
       gpt-3.5-turbo-16k:
         aliases: ["35t16k"]
@@ -71,7 +81,7 @@ apis:
     # Set to 'azure-ad' to use Active Directory
     # Azure OpenAI setup: https://learn.microsoft.com/en-us/azure/cognitive-services/openai/how-to/create-resource
     base-url: https://YOUR_RESOURCE_NAME.openai.azure.com
-    api-key: 
+    api-key:
     api-key-env: AZURE_OPENAI_KEY
     models:
       gpt-4:

--- a/config_template.yml
+++ b/config_template.yml
@@ -2,8 +2,8 @@
 default-model: gpt-4
 # {{ index .Help "format-text" }}
 format-text:
-  markdown: Format the response as markdown without enclosing backticks.
-  json: Format the response as json without enclosing backticks.
+  markdown: '{{ index .Config.FormatText "markdown" }}'
+  json: '{{ index .Config.FormatText "json" }}'
 # {{ index .Help "format" }}
 format: false
 # {{ index .Help "raw" }}

--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestConfig(t *testing.T) {
+	t.Run("old format text", func(t *testing.T) {
+		var cfg Config
+		require.NoError(t, yaml.Unmarshal([]byte("format-text: as markdown"), &cfg))
+		require.Equal(t, FormatText(map[string]string{
+			"markdown": "as markdown",
+		}), cfg.FormatText)
+	})
+	t.Run("new format text", func(t *testing.T) {
+		var cfg Config
+		require.NoError(t, yaml.Unmarshal([]byte("format-text:\n  markdown: as markdown\n  json: as json"), &cfg))
+		require.Equal(t, FormatText(map[string]string{
+			"markdown": "as markdown",
+			"json":     "as json",
+		}), cfg.FormatText)
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/lucasb-eyer/go-colorful v1.2.0
 	github.com/mattn/go-isatty v0.0.20
 	github.com/muesli/termenv v0.15.2
-	github.com/sashabaranov/go-openai v1.16.0
+	github.com/sashabaranov/go-openai v1.17.11
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.8.4

--- a/go.sum
+++ b/go.sum
@@ -108,8 +108,8 @@ github.com/rivo/uniseg v0.4.4/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUc
 github.com/rogpeppe/go-internal v1.6.1 h1:/FiVV8dS/e+YqF2JvO3yXRFbBLTIuSDkuC7aBOAvL+k=
 github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
-github.com/sashabaranov/go-openai v1.16.0 h1:34W6WV84ey6OpW0p2UewZkdMu82AxGC+BzpU6iiauRw=
-github.com/sashabaranov/go-openai v1.16.0/go.mod h1:lj5b/K+zjTSFxVLijLSTDZuP7adOgerWeFyZLUhAKRg=
+github.com/sashabaranov/go-openai v1.17.11 h1:XVr00J8JymJVx8Hjbh/5mG0V4PQHRarBU3v7k2x6MR0=
+github.com/sashabaranov/go-openai v1.17.11/go.mod h1:lj5b/K+zjTSFxVLijLSTDZuP7adOgerWeFyZLUhAKRg=
 github.com/spf13/cobra v1.7.0 h1:hyqWnYt1ZQShIddO5kBpj3vu05/++x6tJ6dg8EC572I=
 github.com/spf13/cobra v1.7.0/go.mod h1:uLxZILRyS/50WlhOIKD7W6V5bgeIt+4sICxh6uRMrb0=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=

--- a/main.go
+++ b/main.go
@@ -61,11 +61,9 @@ func init() {
 }
 
 var (
-	config = Config{
-		FormatAs: "markdown",
-	}
-	db    *convoDB
-	cache *convoCache
+	config = defaultConfig()
+	db     *convoDB
+	cache  *convoCache
 
 	rootCmd = &cobra.Command{
 		Use:           "mods",
@@ -239,12 +237,7 @@ func initFlags() {
 	}
 
 	if config.Format && config.FormatText[config.FormatAs] == "" {
-		switch config.FormatAs {
-		case "json":
-			config.FormatText[config.FormatAs] = "Format the response as json without enclosing backticks."
-		default:
-			config.FormatText[config.FormatAs] = "Format the response as markdown without enclosing backticks."
-		}
+		config.FormatText[config.FormatAs] = defaultConfig().FormatText[config.FormatAs]
 	}
 
 	rootCmd.MarkFlagsMutuallyExclusive(

--- a/main.go
+++ b/main.go
@@ -61,9 +61,11 @@ func init() {
 }
 
 var (
-	config Config
-	db     *convoDB
-	cache  *convoCache
+	config = Config{
+		FormatAs: "markdown",
+	}
+	db    *convoDB
+	cache *convoCache
 
 	rootCmd = &cobra.Command{
 		Use:           "mods",
@@ -199,6 +201,7 @@ func initFlags() {
 	flags.StringVarP(&config.API, "api", "a", config.API, stdoutStyles().FlagDesc.Render(help["api"]))
 	flags.StringVarP(&config.HTTPProxy, "http-proxy", "x", config.HTTPProxy, stdoutStyles().FlagDesc.Render(help["http-proxy"]))
 	flags.BoolVarP(&config.Format, "format", "f", config.Format, stdoutStyles().FlagDesc.Render(help["format"]))
+	flags.StringVar(&config.FormatAs, "format-as", config.FormatAs, stdoutStyles().FlagDesc.Render(help["format-as"]))
 	flags.BoolVarP(&config.Raw, "raw", "r", config.Raw, stdoutStyles().FlagDesc.Render(help["raw"]))
 	flags.IntVarP(&config.IncludePrompt, "prompt", "P", config.IncludePrompt, stdoutStyles().FlagDesc.Render(help["prompt"]))
 	flags.BoolVarP(&config.IncludePromptArgs, "prompt-args", "p", config.IncludePromptArgs, stdoutStyles().FlagDesc.Render(help["prompt-args"]))
@@ -235,8 +238,13 @@ func initFlags() {
 		})
 	}
 
-	if config.Format && config.FormatText == "" {
-		config.FormatText = "Format the response as markdown without enclosing backticks."
+	if config.Format && config.FormatText[config.FormatAs] == "" {
+		switch config.FormatAs {
+		case "json":
+			config.FormatText[config.FormatAs] = "Format the response as json without enclosing backticks."
+		default:
+			config.FormatText[config.FormatAs] = "Format the response as markdown without enclosing backticks."
+		}
 	}
 
 	rootCmd.MarkFlagsMutuallyExclusive(
@@ -244,6 +252,7 @@ func initFlags() {
 		"show",
 		"show-last",
 		"delete",
+		"delete-older-than",
 		"list",
 		"continue",
 		"continue-last",

--- a/mods_test.go
+++ b/mods_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"testing"
 
+	"github.com/sashabaranov/go-openai"
 	"github.com/stretchr/testify/require"
 )
 
@@ -154,5 +155,81 @@ func TestFindCacheOpsDetails(t *testing.T) {
 		err := msg.(modsError)
 		require.Equal(t, "Could not find the conversation.", err.reason)
 		require.EqualError(t, err, errNoMatches.Error())
+	})
+}
+
+var responseTypeCases = map[string]struct {
+	config Config
+	expect openai.ChatCompletionResponseFormatType
+}{
+	"no format": {
+		Config{},
+		openai.ChatCompletionResponseFormatTypeText,
+	},
+	"format markdown": {
+		Config{
+			Format:   true,
+			FormatAs: "markdown",
+			Model:    "gpt-4",
+		},
+		openai.ChatCompletionResponseFormatTypeText,
+	},
+	"format json with unsupported model": {
+		Config{
+			Format:   true,
+			FormatAs: "json",
+			Model:    "gpt-4",
+		},
+		openai.ChatCompletionResponseFormatTypeText,
+	},
+	"format markdown with gpt-4-1106-preview": {
+		Config{
+			Format:   true,
+			FormatAs: "markdown",
+			Model:    "gpt-4-1106-preview",
+		},
+		openai.ChatCompletionResponseFormatTypeText,
+	},
+	"format markdown with gpt-3.5-turbo-1106": {
+		Config{
+			Format:   true,
+			FormatAs: "markdown",
+			Model:    "gpt-3.5-turbo-1106",
+		},
+		openai.ChatCompletionResponseFormatTypeText,
+	},
+	"format json with gpt-4-1106-preview": {
+		Config{
+			Format:   true,
+			FormatAs: "json",
+			Model:    "gpt-4-1106-preview",
+		},
+		openai.ChatCompletionResponseFormatTypeJSONObject,
+	},
+	"format json with gpt-3.5-turbo-1106": {
+		Config{
+			Format:   true,
+			FormatAs: "json",
+			Model:    "gpt-3.5-turbo-1106",
+		},
+		openai.ChatCompletionResponseFormatTypeJSONObject,
+	},
+}
+
+func TestResponseType(t *testing.T) {
+	for k, tc := range responseTypeCases {
+		t.Run(k, func(t *testing.T) {
+			require.Equal(t, tc.expect, responseType(&tc.config))
+		})
+	}
+}
+
+func TestRemoveWhitespace(t *testing.T) {
+	t.Run("only whitespaces", func(t *testing.T) {
+		require.Equal(t, "", removeWhitespace(" \n"))
+	})
+
+	t.Run("regular text", func(t *testing.T) {
+		require.Equal(t, " regular\n ", removeWhitespace(" regular\n "))
 	})
 }


### PR DESCRIPTION
Introduce a new flag, `--format-as`.

It defaults to `markdown`, and is only used when `--format` is also specified.

`--format-as=json` will only set the response type to json in supported models, otherwise it'll only add the format text to the prompt.

Also updated the openai library to support this.

Added to the default configuration both `gpt-4-1106-preview` and `gpt-3.5-turbo-1106`. (update: moved to #190)

Theses are the only models that support the JSON response format.

`format-text` is now a `map[string]string`. Old configs (which have it as a string) will set the specified formatting text to the `markdown` format automatically.
Newly generated configs will have both `markdown` and `json` format texts.

---

closes #167
closes #173