### PR TITLE
fix: do not use a renderer if output is not a tty

### DIFF
--- a/main.go
+++ b/main.go
@@ -86,7 +86,7 @@ var (
 			}
 
 			if !isInputTTY() {
-				opts = append(opts, tea.WithInput(nil))
+				opts = append(opts, tea.WithInput(nil), tea.WithoutRenderer())
 			}
 
 			if isNoArgs() && isInputTTY() {


### PR DESCRIPTION
the renderer will send sequences to clear screen, hide/show mouse, etc, which will not work if output is not a tty.

fixes #198
fixes #86