### PR TITLE
fix: set --quiet if running from vim

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,15 @@ Wrap formatted output at specific width (default is 80)
 
 Use the HTTP proxy to the connect the API endpoints.
 
+## Using within Vim/neovim
+
+You can use mods as an assistant inside Vim.
+Here are some examples:
+
+1. `:'<,'>w !mods explain this`
+1. `:.!mods -f write a copyright footer for mycompany, 2024`
+1. `:'<,'>.!mods improve this code`
+
 ## Whatcha Think?
 
 We’d love to hear your thoughts on this project. Feel free to drop us a note.

--- a/main.go
+++ b/main.go
@@ -91,6 +91,9 @@ var (
 			if !isOutputTTY() {
 				opts = append(opts, tea.WithoutRenderer())
 			}
+			if os.Getenv("VIMRUNTIME") != "" {
+				config.Quiet = true
+			}
 
 			if isNoArgs() && isInputTTY() {
 				err := huh.NewForm(


### PR DESCRIPTION
I reckon that everyone will always run `:!mods -q prompt` within vim, so this sets quiet automatically if `$VIMRUNTIME` is not empty, which AFAIK only is true if running within vim/neovim.


---

![CleanShot 2024-01-25 at 08 52 45@2x](https://github.com/charmbracelet/mods/assets/245435/4b0f9574-a476-4889-ab8f-1679d84bb81e)


Clockwise from top left:

- `:terminal` within neovim running `env | rg VIM`
- `:.!env` from neovim
- `env | rg VIM` from terminal