### PR TITLE
fix: include api name in errors

### DIFF
--- a/mods.go
+++ b/mods.go
@@ -433,7 +433,10 @@ func (m *Mods) handleAPIError(err *openai.APIError, cfg *Config, mod Model, cont
 	case http.StatusNotFound:
 		if mod.Fallback != "" {
 			m.Config.Model = mod.Fallback
-			return m.retry(content, modsError{err: err, reason: "OpenAI API server error."})
+			return m.retry(content, modsError{
+				err:    err,
+				reason: fmt.Sprintf("%s API server error.", mod.API),
+			})
 		}
 		return modsError{err: err, reason: fmt.Sprintf(
 			"Missing model '%s' for API '%s'.",
@@ -450,13 +453,15 @@ func (m *Mods) handleAPIError(err *openai.APIError, cfg *Config, mod Model, cont
 			return m.retry(cutPrompt(err.Message, content), pe)
 		}
 		// bad request (do not retry)
-		return modsError{err: err, reason: "OpenAI API request error."}
+		return modsError{err: err, reason: fmt.Sprintf("%s API request error.", mod.API)}
 	case http.StatusUnauthorized:
 		// invalid auth or key (do not retry)
-		return modsError{err: err, reason: "Invalid OpenAI API key."}
+		return modsError{err: err, reason: fmt.Sprintf("Invalid %s API key.", mod.API)}
 	case http.StatusTooManyRequests:
 		// rate limiting or engine overload (wait and retry)
-		return m.retry(content, modsError{err: err, reason: "You’ve hit your OpenAI API rate limit."})
+		return m.retry(content, modsError{
+			err: err, reason: fmt.Sprintf("You’ve hit your %s API rate limit.", mod.API),
+		})
 	case http.StatusInternalServerError:
 		if mod.API == "openai" {
 			return m.retry(content, modsError{err: err, reason: "OpenAI API server error."})


### PR DESCRIPTION
All errors were citing issues with OpenAI API Key, even if another API endpoint was used. This PR resolves that issue by getting the name of the API used instead of a hard-coded value.