### PR TITLE
Add Perplexity API

### DIFF
--- a/config_template.yml
+++ b/config_template.yml
@@ -72,6 +72,38 @@ apis:
         aliases: ["35"]
         max-input-chars: 12250
         fallback:
+  perplexity:
+    base-url: https://api.perplexity.ai
+    api-key:
+    api-key-env: PERPLEXITY_API_KEY
+    models:
+      codellama-70b-instruct:
+        aliases: ["codellama"]
+        max-input-chars: 16384
+        fallback:
+      mistral-7b-instruct:
+        aliases: ["mistral"]
+        max-input-chars: 16384
+        fallback:
+      mixtral-8x7b-instruct:
+        aliases: ["mixtral-8x"]
+        max-input-chars: 16384
+        fallback:
+      sonar-medium-online:
+        aliases: ["smo", "o"]
+        max-input-chars: 1200
+        fallback:
+      sonar-medium-chat:
+        aliases: ["smc"]
+        max-input-chars: 16384
+        fallback:
+      sonar-small-chat:
+        aliases: ["ssc"]
+        max-input-chars: 16384
+        fallback:
+      sonar-small-online:
+        aliases: ["sso"]
+        max-input-chars: 1200
   groq:
     base-url: https://api.groq.com/openai/v1
     api-key-env: GROQ_API_KEY

--- a/config_template.yml
+++ b/config_template.yml
@@ -80,27 +80,21 @@ apis:
       codellama-70b-instruct:
         aliases: ["codellama"]
         max-input-chars: 16384
-        fallback:
       mistral-7b-instruct:
         aliases: ["mistral"]
         max-input-chars: 16384
-        fallback:
       mixtral-8x7b-instruct:
         aliases: ["mixtral-8x"]
         max-input-chars: 16384
-        fallback:
       sonar-medium-online:
         aliases: ["smo", "o"]
         max-input-chars: 1200
-        fallback:
       sonar-medium-chat:
         aliases: ["smc"]
         max-input-chars: 16384
-        fallback:
       sonar-small-chat:
         aliases: ["ssc"]
         max-input-chars: 16384
-        fallback:
       sonar-small-online:
         aliases: ["sso"]
         max-input-chars: 1200


### PR DESCRIPTION
1.  Added [current Perplexity models](https://docs.perplexity.ai/docs/model-cards) to default configuration template.  

2.  Online models were providing low quality responses.  [Perplexity docs](https://docs.perplexity.ai/docs/model-cards#online-llms) state, `It is recommended to use only single-turn conversations and avoid system prompts for the online LLMs (sonar-small-online and sonar-medium-online).`

    Experimented, and omitting some of the `ChatCompletionRequest` properties fixes response quality issues for these online models, so added a conditional to mods.go.

Closes #201 
