### PR TITLE
Adds support for RunPod

### DIFF
--- a/config_template.yml
+++ b/config_template.yml
@@ -135,3 +135,11 @@ apis:
         aliases: ["az35"]
         max-input-chars: 12250
         fallback:
+  runpod:
+    # https://docs.runpod.io/serverless/workers/vllm/openai-compatibility
+    base-url: https://api.runpod.ai/v2/${YOUR_ENDPOINT}/openai/v1
+    api-key: RUNPOD_API_KEY
+    models:
+      openchat/openchat-3.5-1210:
+        aliases: ["openchat"]
+        max-input-chars: 8192

--- a/config_template.yml
+++ b/config_template.yml
@@ -138,7 +138,8 @@ apis:
   runpod:
     # https://docs.runpod.io/serverless/workers/vllm/openai-compatibility
     base-url: https://api.runpod.ai/v2/${YOUR_ENDPOINT}/openai/v1
-    api-key: RUNPOD_API_KEY
+    api-key:
+    api-key-env: RUNPOD_API_KEY
     models:
       openchat/openchat-3.5-1210:
         aliases: ["openchat"]


### PR DESCRIPTION
Adds support for RunPod and OpenAI compatible Workers.
https://docs.runpod.io/serverless/workers/vllm/openai-compatibility

User must supply their Endpoint by setting it as an env. variable and passing in their model name.