### PR TITLE
feat: allow to use role from URL/filepath

### DIFF
--- a/load.go
+++ b/load.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"io"
+	"net/http"
+	"os"
+	"strings"
+)
+
+func loadMsg(msg string) (string, error) {
+	if strings.HasPrefix(msg, "https://") || strings.HasPrefix(msg, "http://") {
+		resp, err := http.Get(msg) //nolint: gosec
+		if err != nil {
+			return "", err
+		}
+		defer func() { _ = resp.Body.Close() }()
+		bts, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return "", err
+		}
+		return string(bts), nil
+	}
+
+	if strings.HasPrefix(msg, "file://") {
+		bts, err := os.ReadFile(strings.TrimPrefix(msg, "file://"))
+		if err != nil {
+			return "", err
+		}
+		return string(bts), nil
+	}
+
+	return msg, nil
+}

--- a/load_test.go
+++ b/load_test.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoad(t *testing.T) {
+	const content = "just text"
+	t.Run("normal msg", func(t *testing.T) {
+		msg, err := loadMsg(content)
+		require.NoError(t, err)
+		require.Equal(t, content, msg)
+	})
+
+	t.Run("file", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "foo.txt")
+		require.NoError(t, os.WriteFile(path, []byte(content), 0644))
+
+		msg, err := loadMsg("file://" + path)
+		require.NoError(t, err)
+		require.Equal(t, content, msg)
+	})
+
+	t.Run("http url", func(t *testing.T) {
+		msg, err := loadMsg("http://raw.githubusercontent.com/charmbracelet/mods/main/LICENSE")
+		require.NoError(t, err)
+		require.Contains(t, msg, "MIT License")
+	})
+
+	t.Run("https url", func(t *testing.T) {
+		msg, err := loadMsg("https://raw.githubusercontent.com/charmbracelet/mods/main/LICENSE")
+		require.NoError(t, err)
+		require.Contains(t, msg, "MIT License")
+	})
+}

--- a/mods.go
+++ b/mods.go
@@ -367,9 +367,16 @@ func (m *Mods) startCompletionCmd(content string) tea.Cmd {
 		}
 
 		for _, msg := range cfg.Roles[cfg.Role] {
+			content, err := loadMsg(msg)
+			if err != nil {
+				return modsError{
+					err:    err,
+					reason: "Could not use role",
+				}
+			}
 			m.messages = append(m.messages, openai.ChatCompletionMessage{
 				Role:    openai.ChatMessageRoleSystem,
-				Content: msg,
+				Content: content,
 			})
 		}
 


### PR DESCRIPTION
This allows to set a role message to either a http/https URL or a filepath (prefixed with `file://`).

Solves #235