### PR TITLE
feat(ui): provide suggested use for convo ID

### DIFF
--- a/main.go
+++ b/main.go
@@ -509,7 +509,18 @@ func printList(conversations []Conversation) {
 		_ = clipboard.WriteAll(selected)
 		termenv.Copy(selected)
 		printConfirmation("COPIED", selected)
-
+		// suggest actions to use this conversation ID
+		fmt.Println(stdoutStyles().Comment.Render(
+			"You can use this conversation ID with the following commands:",
+		))
+		suggestions := []string{"show", "continue", "delete"}
+		for _, flag := range suggestions {
+			fmt.Printf(
+				"  %-44s %s\n",
+				stdoutStyles().Flag.Render("--"+flag),
+				stdoutStyles().FlagDesc.Render(help[flag]),
+			)
+		}
 		return
 	}
 


### PR DESCRIPTION
After copying the conversation ID I was left wondering "what now?", so here's a
PR to include some suggested actions to use the conversation IDs. I kept it
simple, just suggesting the long form usage of the flag as it was taking a bit for
me to figure out how to get specific flags from cobra.

preview:
![image](https://github.com/charmbracelet/mods/assets/15822994/047118a5-0c5f-490b-a3dc-8312a1605aba)
