### PR TITLE
Update Groq Models

### DIFF
--- a/config_template.yml
+++ b/config_template.yml
@@ -105,6 +105,9 @@ apis:
       gemma-7b-it:
         aliases: ["gemma"]
         max-input-chars: 24500
+      llama3-70b-8192:
+        aliases: ["llama3"]
+        max-input-chars: 24500
       mixtral-8x7b-32768:
         aliases: ["mixtral"]
         max-input-chars: 98000

--- a/config_template.yml
+++ b/config_template.yml
@@ -102,6 +102,9 @@ apis:
     base-url: https://api.groq.com/openai/v1
     api-key-env: GROQ_API_KEY
     models:
+      gemma-7b-it:
+        aliases: ["gemma"]
+        max-input-chars: 24500
       mixtral-8x7b-32768:
         aliases: ["mixtral"]
         max-input-chars: 98000

--- a/config_template.yml
+++ b/config_template.yml
@@ -105,9 +105,6 @@ apis:
       mixtral-8x7b-32768:
         aliases: ["mixtral"]
         max-input-chars: 98000
-      llama2-70b-4096:
-        aliases: ["llama2"]
-        max-input-chars: 12250
   localai:
     # LocalAI setup instructions: https://github.com/go-skynet/LocalAI#example-use-gpt4all-j-model
     base-url: http://localhost:8080

--- a/config_template.yml
+++ b/config_template.yml
@@ -106,7 +106,11 @@ apis:
         aliases: ["gemma"]
         max-input-chars: 24500
       llama3-70b-8192:
-        aliases: ["llama3"]
+        aliases: ["llama3", "llama3-70b"]
+        max-input-chars: 24500
+        fallback: llama3-8b-8192
+      llama3-8b-8192:
+        aliases: ["llama3-8b"]
         max-input-chars: 24500
       mixtral-8x7b-32768:
         aliases: ["mixtral"]

--- a/config_template.yml
+++ b/config_template.yml
@@ -101,7 +101,7 @@ apis:
   groq:
     base-url: https://api.groq.com/openai/v1
     api-key-env: GROQ_API_KEY
-    models:
+    models: # https://console.groq.com/docs/models
       gemma-7b-it:
         aliases: ["gemma"]
         max-input-chars: 24500


### PR DESCRIPTION
Llama2 has been discontinued by Groq in favour of Llama3. It has a larger context window and also has both 70b and 8b models.

Groq also provides Google Gemma (7b) as well.

Source: https://console.groq.com/docs/models