### PR TITLE
Fix issue with Anthropic not supporting the `system` role

### DIFF
--- a/stream.go
+++ b/stream.go
@@ -90,9 +90,21 @@ func (m *Mods) createAnthropicStream(content string, accfg AnthropicClientConfig
 		return err
 	}
 
+	// Anthropic doesn't support the System role so we need to remove those message
+	// and, instead, store their content on the `System` request value.
+	messages := []openai.ChatCompletionMessage{}
+
+	for _, message := range m.messages {
+		if message.Role == openai.ChatMessageRoleSystem {
+			m.system += message.Content + "\n"
+		} else {
+			messages = append(messages, message)
+		}
+	}
+
 	req := AnthropicMessageCompletionRequest{
 		Model:         mod.Name,
-		Messages:      m.messages,
+		Messages:      messages,
 		System:        m.system,
 		Stream:        true,
 		Temperature:   noOmitFloat(cfg.Temperature),


### PR DESCRIPTION
The Anthropic API doesn't support the `System` prompt, so the `format` and `role` options cause it to fail.

I fixed it by removing the messages with the `System` role and appending their message to the `System` request value instead.