### PR TITLE
Fix winget command with full package ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Set the `GROQ_API_KEY` environment variable to a valid key, which you can get
 brew install charmbracelet/tap/mods
 
 # Windows (with Winget)
-winget install mods
+winget install charmbracelet.mods
 
 # Windows (with Scoop)
 scoop bucket add charm https://github.com/charmbracelet/scoop-bucket.git


### PR DESCRIPTION
I'm sure it worked at some point, but now winget says there's multiple packages matching "mods" so the full ID is required.

```shell
> winget install mods
Multiple packages found matching input criteria. Please refine the input.
Name        Id                 Source
--------------------------------------
JGC Connect 9NM2X7TGDDWD       msstore
mods        charmbracelet.mods winget
```
but `winget install charmbracelet.mods` works. ✨ 
