### PR TITLE
fix: do not show examples in subcommands

### DIFF
--- a/config.go
+++ b/config.go
@@ -319,12 +319,13 @@ func usageFunc(cmd *cobra.Command) error {
 			)
 		}
 	})
-	desc, example := randomExample()
-	fmt.Printf(
-		"\nExample:\n  %s\n  %s\n",
-		stdoutStyles().Comment.Render("# "+desc),
-		cheapHighlighting(stdoutStyles(), example),
-	)
+	if cmd.HasExample() {
+		fmt.Printf(
+			"\nExample:\n  %s\n  %s\n",
+			stdoutStyles().Comment.Render("# "+cmd.Example),
+			cheapHighlighting(stdoutStyles(), examples[cmd.Example]),
+		)
+	}
 
 	return nil
 }

--- a/examples.go
+++ b/examples.go
@@ -11,13 +11,13 @@ var examples = map[string]string{
 	"Let GPT pick something to watch": `ls ~/vids | mods "Pick 5 action packed shows from the 80s from this list" | gum choose | xargs vlc`,
 }
 
-func randomExample() (string, string) {
+func randomExample() string {
 	keys := make([]string, 0, len(examples))
 	for k := range examples {
 		keys = append(keys, k)
 	}
 	desc := keys[rand.Intn(len(keys))] //nolint:gosec
-	return desc, examples[desc]
+	return desc
 }
 
 func cheapHighlighting(s styles, code string) string {

--- a/main.go
+++ b/main.go
@@ -77,6 +77,7 @@ var (
 		Use:           "mods",
 		SilenceUsage:  true,
 		SilenceErrors: true,
+		Example:       randomExample(),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			config.Prefix = removeWhitespace(strings.Join(args, " "))
 


### PR DESCRIPTION
The examples we show are only relevant to the root command, so we can show them only in that case.