### PR TITLE
fix: improve completion cmd handling 

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ go install github.com/charmbracelet/mods@latest
 ```
 
 <details>
-<summary>Completions</summary>
+<summary>Shell Completions</summary>
 
 All the packages and archives come with pre-generated completion files for Bash,
 ZSH, Fish, and PowerShell.

--- a/README.md
+++ b/README.md
@@ -91,10 +91,10 @@ ZSH, Fish, and PowerShell.
 If you built it from source, you can generate them with:
 
 ```bash
-__MODS_CMP_ENABLED=1 mods completion bash -h
-__MODS_CMP_ENABLED=1 mods completion zsh -h
-__MODS_CMP_ENABLED=1 mods completion fish -h
-__MODS_CMP_ENABLED=1 mods completion powershell -h
+mods completion bash -h
+mods completion zsh -h
+mods completion fish -h
+mods completion powershell -h
 ```
 
 If you use a package (like Homebrew, Debs, etc), the completions should be set

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestIsCompletionCmd(t *testing.T) {
+	for args, is := range map[string]bool{
+		"":                                     false,
+		"something":                            false,
+		"something something":                  false,
+		"completion for my bash script how to": false,
+		"completion bash how to":               false,
+		"completion":                           false,
+		"completion -h":                        true,
+		"completion --help":                    true,
+		"completion help":                      true,
+		"completion bash":                      true,
+		"completion fish":                      true,
+		"completion zsh":                       true,
+		"completion powershell":                true,
+		"completion bash -h":                   true,
+		"completion fish -h":                   true,
+		"completion zsh -h":                    true,
+		"completion powershell -h":             true,
+		"completion bash --help":               true,
+		"completion fish --help":               true,
+		"completion zsh --help":                true,
+		"completion powershell --help":         true,
+		"__complete":                           true,
+		"__complete blah blah blah":            true,
+	} {
+		t.Run(args, func(t *testing.T) {
+			vargs := append([]string{"mods"}, strings.Fields(args)...)
+			if b := isCompletionCmd(vargs); b != is {
+				t.Errorf("%v: expected %v, got %v", vargs, is, b)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The way it works today, its not possible to install the completions
automatically on Nix, as the build needs to be pure.

This is kinda hacky, but I think it'll work: we only allow the
completion cmd to run if there is good evidence that it is a completion
command, and not a prompt that happens to start with completion.

refs https://github.com/charmbracelet/mods/issues/287