### PR TITLE
Add Mistral provider to config template

### DIFF
--- a/config_template.yml
+++ b/config_template.yml
@@ -179,3 +179,14 @@ apis:
       openchat/openchat-3.5-1210:
         aliases: ["openchat"]
         max-input-chars: 8192
+  mistral:
+    base-url: https://api.mistral.ai/v1
+    api-key:
+    api-key-env: MISTRAL_API_KEY
+    models: # https://docs.mistral.ai/getting-started/models/
+      mistral-large-latest:
+        aliases: ["mistral-large"]
+        max-input-chars: 384000
+      open-mistral-nemo:
+        aliases: ["mistral-nemo"]
+        max-input-chars: 384000


### PR DESCRIPTION
Mistral is known for their open models (originally Mistral 7b, then their Mixtral MoE model), but they also have proprietary models that they're offering through their inference API "La Plateforme": https://docs.mistral.ai/deployment/laplateforme/overview/

The original purely proprietary models (small, medium, large) are not SOTA anymore and might get deprecated at some point, but their latest model "Mistral Large 2" is supposedly close to Llama 3.1 405B (as per https://mistral.ai/news/mistral-large-2407/). (And while not entire proprietary, its weights can only be used under their non-commercial "Mistral Research License", while their platform allows commercial use)

The API is OpenAI-compatible, so `mods` works with it out-of-the-box.