### PR TITLE
fix: Correct baseURL configuration for Anthropic API

### DIFF
--- a/mods.go
+++ b/mods.go
@@ -321,7 +321,7 @@ func (m *Mods) startCompletionCmd(content string) tea.Cmd {
 			}
 			accfg = DefaultAnthropicConfig(key)
 			if api.BaseURL != "" {
-				ccfg.BaseURL = api.BaseURL
+				accfg.BaseURL = api.BaseURL
 			}
 			if api.Version != "" {
 				accfg.Version = AnthropicAPIVersion(api.Version)


### PR DESCRIPTION
Fixed an issue where Anthropic base-url configuration did not work.