### PR TITLE
fix: raw output being rendered twice

### DIFF
--- a/main.go
+++ b/main.go
@@ -78,14 +78,14 @@ var (
 		RunE: func(cmd *cobra.Command, args []string) error {
 			config.Prefix = removeWhitespace(strings.Join(args, " "))
 
-			opts := []tea.ProgramOption{
-				tea.WithOutput(os.Stderr),
-			}
+			opts := []tea.ProgramOption{}
 
-			if !isInputTTY() {
+			if !isInputTTY() || config.Raw {
 				opts = append(opts, tea.WithInput(nil))
 			}
-			if !isOutputTTY() {
+			if isOutputTTY() && !config.Raw {
+				opts = append(opts, tea.WithOutput(os.Stderr))
+			} else {
 				opts = append(opts, tea.WithoutRenderer())
 			}
 			if os.Getenv("VIMRUNTIME") != "" {

--- a/mods.go
+++ b/mods.go
@@ -215,7 +215,7 @@ func (m *Mods) View() string {
 			return m.glamOutput
 		}
 
-		if isOutputTTY() {
+		if isOutputTTY() && !m.Config.Raw {
 			return m.Output
 		}
 


### PR DESCRIPTION
the output was being print as part of the bubbletea loop, but it wasn't respecting terminal sizes or anything.

also, in some places, it should have been checking for `--raw` but wasn't.

this pr should fix both issues.