### PR TITLE
feat: Add support for user request parameter

### DIFF
--- a/config.go
+++ b/config.go
@@ -88,6 +88,7 @@ type API struct {
 	Version   string           `yaml:"version"`
 	BaseURL   string           `yaml:"base-url"`
 	Models    map[string]Model `yaml:"models"`
+	User      string           `yaml:"user"`
 }
 
 // APIs is a type alias to allow custom YAML decoding.
@@ -175,6 +176,7 @@ type Config struct {
 	ListRoles         bool
 	Delete            string
 	DeleteOlderThan   time.Duration
+	User              string
 
 	cacheReadFromID, cacheWriteToID, cacheWriteToTitle string
 }

--- a/mods.go
+++ b/mods.go
@@ -351,6 +351,9 @@ func (m *Mods) startCompletionCmd(content string) tea.Cmd {
 			if mod.API == "azure-ad" {
 				ccfg.APIType = openai.APITypeAzureAD
 			}
+			if api.User != "" {
+				cfg.User = api.User
+			}
 		default:
 			key, err := m.ensureKey(api, "OPENAI_API_KEY", "https://platform.openai.com/account/api-keys")
 			if err != nil {

--- a/stream.go
+++ b/stream.go
@@ -25,6 +25,7 @@ func (m *Mods) createOpenAIStream(content string, ccfg openai.ClientConfig, mod 
 		Model:    mod.Name,
 		Messages: m.messages,
 		Stream:   true,
+		User:     cfg.User,
 	}
 
 	if mod.API != "perplexity" || !strings.Contains(mod.Name, "online") {


### PR DESCRIPTION
In certain OpenAI Azure setups, the `user` parameter is a mandatory filed in the requests. Failing to include it results in a 422 error code. This patch introduces a mechanism to add the user parameter, allowing the use of mods in such setups. 
I would appreciate your feedback on this change and any suggestions for improvement. Thank you!