### PR TITLE
feat: add `-R` shorthand to `--role`

### DIFF
--- a/main.go
+++ b/main.go
@@ -252,7 +252,7 @@ func initFlags() {
 	flags.BoolVar(&config.ResetSettings, "reset-settings", config.ResetSettings, stdoutStyles().FlagDesc.Render(help["reset-settings"]))
 	flags.BoolVar(&config.Settings, "settings", false, stdoutStyles().FlagDesc.Render(help["settings"]))
 	flags.BoolVar(&config.Dirs, "dirs", false, stdoutStyles().FlagDesc.Render(help["dirs"]))
-	flags.StringVar(&config.Role, "role", "R", config.Role, stdoutStyles().FlagDesc.Render(help["role"]))
+	flags.StringVarP(&config.Role, "role", "R", config.Role, stdoutStyles().FlagDesc.Render(help["role"]))
 	flags.BoolVar(&config.ListRoles, "list-roles", config.ListRoles, stdoutStyles().FlagDesc.Render(help["list-roles"]))
 	flags.StringVar(&config.Theme, "theme", "charm", stdoutStyles().FlagDesc.Render(help["theme"]))
 	flags.Lookup("prompt").NoOptDefVal = "-1"

--- a/main.go
+++ b/main.go
@@ -252,7 +252,7 @@ func initFlags() {
 	flags.BoolVar(&config.ResetSettings, "reset-settings", config.ResetSettings, stdoutStyles().FlagDesc.Render(help["reset-settings"]))
 	flags.BoolVar(&config.Settings, "settings", false, stdoutStyles().FlagDesc.Render(help["settings"]))
 	flags.BoolVar(&config.Dirs, "dirs", false, stdoutStyles().FlagDesc.Render(help["dirs"]))
-	flags.StringVar(&config.Role, "role", config.Role, stdoutStyles().FlagDesc.Render(help["role"]))
+	flags.StringVar(&config.Role, "role", "R", config.Role, stdoutStyles().FlagDesc.Render(help["role"]))
 	flags.BoolVar(&config.ListRoles, "list-roles", config.ListRoles, stdoutStyles().FlagDesc.Render(help["list-roles"]))
 	flags.StringVar(&config.Theme, "theme", "charm", stdoutStyles().FlagDesc.Render(help["theme"]))
 	flags.Lookup("prompt").NoOptDefVal = "-1"


### PR DESCRIPTION
Fixes #299.

_I hope that there are no other parts in the code that should be changed._

To test the change:

```bash
mods -R default "What's up?"
```

1. Run this on the main branch version. This should give the following error:
    ```
    Check out  mods -h  for help.
    
    unknown shorthand flag: 'R' in -R%!(EXTRA string=  )
    ```
2. Run this on my branch. This should give no errors.