### PR TITLE
feat(copilot): improved support for AccessToken and Enterprise API

### DIFF
--- a/config_template.yml
+++ b/config_template.yml
@@ -94,8 +94,24 @@ apis:
   copilot:
     base-url: https://api.githubcopilot.com
     models:
-      gpt-4o:
+      gpt-4o-2024-05-13:
+        aliases: ["4o-2024", "4o", "gpt-4o"]
         max-input-chars: 392000
+      gpt-4:
+        aliases: ["4"]
+        max-input-chars: 24500
+      gpt-3.5-turbo:
+        aliases: ["35t"]
+        max-input-chars: 12250
+      o1-preview-2024-09-12:
+        aliases: ["o1-preview", "o1p"]
+        max-input-chars: 128000
+      o1-mini-2024-09-12:
+        aliases: ["o1-mini", "o1m"]
+        max-input-chars: 128000
+      claude-3.5-sonnet:
+        aliases: ["claude3.5-sonnet", "sonnet-3.5", "claude-3-5-sonnet"]
+        max-input-chars: 680000
   anthropic:
     base-url: https://api.anthropic.com/v1
     api-key:

--- a/copilot.go
+++ b/copilot.go
@@ -3,11 +3,21 @@ package main
 import (
 	"encoding/json"
 	"os"
+	"path/filepath"
+	"runtime"
 )
 
 func getCopilotAuthToken() (string, error) {
-	// TODO: Windows?
-	bts, err := os.ReadFile(os.Getenv("HOME") + "/.config/github-copilot/hosts.json")
+	var sessionPath string
+	if runtime.GOOS == "windows" {
+		// C:\Users\user\AppData\Local\github-copilot\hosts.json
+		sessionPath = filepath.Join(os.Getenv("LOCALAPPDATA"), "github-copilot", "hosts.json")
+	} else {
+		// ~/.config/github-copilot/hosts.json
+		sessionPath = filepath.Join(os.Getenv("HOME"), ".config/github-copilot", "hosts.json")
+	}
+
+	bts, err := os.ReadFile(sessionPath)
 	if err != nil {
 		return "", err
 	}

--- a/copilot.go
+++ b/copilot.go
@@ -2,28 +2,148 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
+	"net/http"
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
+	"time"
 )
 
-func getCopilotAuthToken() (string, error) {
-	var sessionPath string
-	if runtime.GOOS == "windows" {
-		// C:\Users\user\AppData\Local\github-copilot\hosts.json
-		sessionPath = filepath.Join(os.Getenv("LOCALAPPDATA"), "github-copilot", "hosts.json")
-	} else {
-		// ~/.config/github-copilot/hosts.json
-		sessionPath = filepath.Join(os.Getenv("HOME"), ".config/github-copilot", "hosts.json")
+const (
+	CopilotChatAuthURL   = "https://api.github.com/copilot_internal/v2/token"
+	CopilotEditorVersion = "vscode/1.95.3"
+	CopilotUserAgent     = "curl/7.81.0" // Necessay to bypass the user-agent check
+)
+
+type CopilotAccessToken struct {
+	Token     string `json:"token"`
+	ExpiresAt int64  `json:"expires_at"`
+	Endpoints struct {
+		API           string `json:"api"` // Can change in Github Enterprise instances
+		OriginTracker string `json:"origin-tracker"`
+		Proxy         string `json:"proxy"`
+		Telemetry     string `json:"telemetry"`
+	} `json:"endpoints"`
+	ErrorDetails *struct {
+		URL            string `json:"url,omitempty"`
+		Message        string `json:"message,omitempty"`
+		Title          string `json:"title,omitempty"`
+		NotificationID string `json:"notification_id,omitempty"`
+	} `json:"error_details,omitempty"`
+}
+
+type CopilotHTTPClient struct {
+	client      *http.Client
+	AccessToken *CopilotAccessToken
+}
+
+func NewCopilotHTTPClient() *CopilotHTTPClient {
+	return &CopilotHTTPClient{
+		client: &http.Client{},
+	}
+}
+
+func (c *CopilotHTTPClient) Do(req *http.Request) (*http.Response, error) {
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Editor-Version", CopilotEditorVersion)
+	req.Header.Set("User-Agent", CopilotUserAgent)
+
+	var isTokenExpired bool = c.AccessToken != nil && c.AccessToken.ExpiresAt < time.Now().Unix()
+
+	if c.AccessToken == nil || isTokenExpired {
+		// Use the base http.Client for token requests to avoid recursion
+		accessToken, err := getCopilotAccessToken(c.client)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get access token: %w", err)
+		}
+
+		c.AccessToken = &accessToken
 	}
 
-	bts, err := os.ReadFile(sessionPath)
+	return c.client.Do(req)
+}
+
+func getCopilotRefreshToken() (string, error) {
+	configPath := filepath.Join(os.Getenv("HOME"), ".config/github-copilot")
+	if runtime.GOOS == "windows" {
+		configPath = filepath.Join(os.Getenv("LOCALAPPDATA"), "github-copilot")
+	}
+
+	// Check both possible config file locations
+	configFiles := []string{
+		filepath.Join(configPath, "hosts.json"),
+		filepath.Join(configPath, "apps.json"),
+	}
+
+	// Try to get token from config files
+	for _, path := range configFiles {
+		token, err := extractCopilotTokenFromFile(path)
+		if err == nil && token != "" {
+			return token, nil
+		}
+	}
+
+	return "", fmt.Errorf("no token found in %s", strings.Join(configFiles, ", "))
+}
+
+func extractCopilotTokenFromFile(path string) (string, error) {
+	bytes, err := os.ReadFile(path)
 	if err != nil {
 		return "", err
 	}
-	hosts := map[string]map[string]string{}
-	if err := json.Unmarshal(bts, &hosts); err != nil {
+
+	var config map[string]json.RawMessage
+	if err := json.Unmarshal(bytes, &config); err != nil {
 		return "", err
 	}
-	return hosts["github.com"]["oauth_token"], nil
+
+	for key, value := range config {
+		if key == "github.com" || strings.HasPrefix(key, "github.com:") {
+			var tokenData map[string]string
+			if err := json.Unmarshal(value, &tokenData); err != nil {
+				continue
+			}
+			if token, exists := tokenData["oauth_token"]; exists {
+				return token, nil
+			}
+		}
+	}
+
+	return "", fmt.Errorf("no token found in %s", path)
+}
+
+func getCopilotAccessToken(client *http.Client) (CopilotAccessToken, error) {
+	refreshToken, err := getCopilotRefreshToken()
+	if err != nil {
+		return CopilotAccessToken{}, fmt.Errorf("failed to get refresh token: %w", err)
+	}
+
+	tokenReq, err := http.NewRequest(http.MethodGet, CopilotChatAuthURL, nil)
+	if err != nil {
+		return CopilotAccessToken{}, fmt.Errorf("failed to create token request: %w", err)
+	}
+
+	tokenReq.Header.Set("Authorization", "token "+refreshToken)
+	tokenReq.Header.Set("Accept", "application/json")
+	tokenReq.Header.Set("Editor-Version", CopilotEditorVersion)
+	tokenReq.Header.Set("User-Agent", CopilotUserAgent)
+
+	tokenResp, err := client.Do(tokenReq)
+	if err != nil {
+		return CopilotAccessToken{}, fmt.Errorf("failed to get access token: %w", err)
+	}
+	defer tokenResp.Body.Close()
+
+	var tokenResponse CopilotAccessToken
+	if err := json.NewDecoder(tokenResp.Body).Decode(&tokenResponse); err != nil {
+		return CopilotAccessToken{}, fmt.Errorf("failed to decode token response: %w", err)
+	}
+
+	if tokenResponse.ErrorDetails != nil {
+		return CopilotAccessToken{}, fmt.Errorf("token error: %s", tokenResponse.ErrorDetails.Message)
+	}
+
+	return tokenResponse, nil
 }

--- a/mods.go
+++ b/mods.go
@@ -357,15 +357,15 @@ func (m *Mods) startCompletionCmd(content string) tea.Cmd {
 				cfg.User = api.User
 			}
 		case "copilot":
-			copilotHttpClient := NewCopilotHTTPClient()
-			accessToken, err := getCopilotAccessToken(copilotHttpClient.client)
+			ghCopilotHTTPClient := newCopilotHTTPClient()
+			accessToken, err := getCopilotAccessToken(ghCopilotHTTPClient.client)
 			if err != nil {
 				return modsError{err, "Copilot authentication failed"}
 			}
 
 			ccfg = openai.DefaultConfig(accessToken.Token)
-			ccfg.HTTPClient = copilotHttpClient
-			ccfg.HTTPClient.(*CopilotHTTPClient).AccessToken = &accessToken
+			ccfg.HTTPClient = ghCopilotHTTPClient
+			ccfg.HTTPClient.(*copilotHTTPClient).AccessToken = &accessToken
 			ccfg.BaseURL = ordered.First(api.BaseURL, accessToken.Endpoints.API)
 
 		default:

--- a/mods.go
+++ b/mods.go
@@ -357,12 +357,17 @@ func (m *Mods) startCompletionCmd(content string) tea.Cmd {
 				cfg.User = api.User
 			}
 		case "copilot":
-			token, err := getCopilotAuthToken()
+			copilotHttpClient := NewCopilotHTTPClient()
+			accessToken, err := getCopilotAccessToken(copilotHttpClient.client)
 			if err != nil {
 				return modsError{err, "Copilot authentication failed"}
 			}
-			ccfg = openai.DefaultConfig(token)
-			ccfg.BaseURL = api.BaseURL
+
+			ccfg = openai.DefaultConfig(accessToken.Token)
+			ccfg.HTTPClient = copilotHttpClient
+			ccfg.HTTPClient.(*CopilotHTTPClient).AccessToken = &accessToken
+			ccfg.BaseURL = ordered.First(api.BaseURL, accessToken.Endpoints.API)
+
 		default:
 			key, err := m.ensureKey(api, "OPENAI_API_KEY", "https://platform.openai.com/account/api-keys")
 			if err != nil {


### PR DESCRIPTION
Implements GitHub Copilot authentication with a new HTTP HttpClient, including token handling and support for new models.

### Authentication and Configuration Updates:

* [`copilot.go`](diffhunk://#diff-458af75f479d120c6a67cc8de8f4c8488fcdfd0b7175b29191beff1fee01c71dR5-R148): Introduced a new `CopilotHTTPClient` struct to manage HTTP requests and token handling for Copilot, including methods for retrieving and refreshing tokens. This change also includes defining constants for the Copilot authentication URL, editor version, and user-agent.

* [`mods.go`](diffhunk://#diff-d92d2fa2f22fc443e1ae12da3fc2e8556aa5e643eb96c0f72c013ea3b43495e5L360-R370): Updated the `startCompletionCmd` function to use the new `CopilotHTTPClient` for authentication, replacing the previous method of sending the RefreshToken to the API. This ensures that the token is properly managed and refreshed as needed.

### Model Configuration Updates:

* [`config_template.yml`](diffhunk://#diff-4d3271dfec3558167d9e0aa882e82e40a412465b4e9eee71dbe74a794b0d30eaL97-R114): Added new model configurations for `gpt-4`, `gpt-3.5-turbo`, `o1-preview-2024-09-12`, `o1-mini-2024-09-12`, and `claude-3.5-sonnet`, including their respective aliases and maximum input characters. Updated the existing `gpt-4o` model configuration to `gpt-4o-2024-05-13` with new aliases.

* [`copilot.go`](diffhunk://#diff-458af75f479d120c6a67cc8de8f4c8488fcdfd0b7175b29191beff1fee01c71dR6-R20): 
> - Add support for Windows file paths using runtime OS detection [[1]](https://github.com/orgs/community/discussions/38217#discussioncomment-4059872)
> - Handle new Copilot token format from apps.json [[2]](https://github.com/zed-industries/zed/issues/21255#issuecomment-2508940898)
> - Support both legacy and new token storage formats 

### Future work:
- [x] Cache AccessToken across conversations (#408)
- [ ] Implement Device Authentication flow
> Officially, the only way to that is to use the compiled LSP from the VIM plugin[[3](https://github.com/github/copilot.vim), [4](https://github.com/MinusGix/lapce-copilot/blob/6b244612043157beb0f509b7ba16de0b5e7d95f4/src/main.rs#L218), [5](https://github.com/zed-industries/zed/blob/7e6233d70f329e400e3945ee4307300f3a9df272/crates/copilot/src/copilot.rs#L991)], so you can generate the `~/.config/github-copilot` folder automatically.
> 
> But you can also login direcly like a copilot extension[[6]](https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/authorizing-oauth-apps#device-flow) and the vscode CopilotChat ApplicationID.

**References:**
1. https://github.com/orgs/community/discussions/38217#discussioncomment-4059872
2. https://github.com/zed-industries/zed/issues/21255#issuecomment-2508940898
3. https://github.com/github/copilot.vim
4. https://github.com/MinusGix/lapce-copilot/blob/6b244612043157beb0f509b7ba16de0b5e7d95f4/src/main.rs#L218
5. https://github.com/zed-industries/zed/blob/7e6233d70f329e400e3945ee4307300f3a9df272/crates/copilot/src/copilot.rs#L991
6. https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/authorizing-oauth-apps#device-flow