### PR TITLE
refactor(cache): improve caching system and add expiring cache

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -15,56 +15,108 @@ const cacheExt = ".gob"
 
 var errInvalidID = errors.New("invalid id")
 
-type convoCache struct {
-	dir string
+type CacheType string
+
+const (
+	ConversationCache CacheType = "conversations"
+)
+
+// Cache represents a generic cache that can store any type
+type Cache[T any] struct {
+	baseDir string
+	cType   CacheType
 }
 
-func newCache(dir string) *convoCache {
-	return &convoCache{dir}
+// NewCache creates a new cache instance
+func NewCache[T any](baseDir string, cacheType CacheType) (*Cache[T], error) {
+	cacheDir := filepath.Join(baseDir, string(cacheType))
+	if err := os.MkdirAll(cacheDir, 0o700); err != nil {
+		return nil, fmt.Errorf("create cache directory: %w", err)
+	}
+	return &Cache[T]{
+		baseDir: baseDir,
+		cType:   cacheType,
+	}, nil
 }
 
-func (c *convoCache) read(id string, messages *[]openai.ChatCompletionMessage) error {
+func (c *Cache[T]) cacheDir() string {
+	return filepath.Join(c.baseDir, string(c.cType))
+}
+
+func (c *Cache[T]) Read(id string, readFn func(io.Reader) error) error {
 	if id == "" {
 		return fmt.Errorf("read: %w", errInvalidID)
 	}
-	file, err := os.Open(filepath.Join(c.dir, id+cacheExt))
+	file, err := os.Open(filepath.Join(c.cacheDir(), id+cacheExt))
 	if err != nil {
 		return fmt.Errorf("read: %w", err)
 	}
 	defer file.Close() //nolint:errcheck
 
-	if err := decode(file, messages); err != nil {
+	if err := readFn(file); err != nil {
 		return fmt.Errorf("read: %w", err)
 	}
 	return nil
 }
 
-func (c *convoCache) write(id string, messages *[]openai.ChatCompletionMessage) error {
+func (c *Cache[T]) Write(id string, writeFn func(io.Writer) error) error {
 	if id == "" {
 		return fmt.Errorf("write: %w", errInvalidID)
 	}
 
-	file, err := os.Create(filepath.Join(c.dir, id+cacheExt))
+	file, err := os.Create(filepath.Join(c.cacheDir(), id+cacheExt))
 	if err != nil {
 		return fmt.Errorf("write: %w", err)
 	}
 	defer file.Close() //nolint:errcheck
 
-	if err := encode(file, messages); err != nil {
+	if err := writeFn(file); err != nil {
 		return fmt.Errorf("write: %w", err)
 	}
 
 	return nil
 }
 
-func (c *convoCache) delete(id string) error {
+func (c *Cache[T]) Delete(id string) error {
 	if id == "" {
 		return fmt.Errorf("delete: %w", errInvalidID)
 	}
-	if err := os.Remove(filepath.Join(c.dir, id+cacheExt)); err != nil {
+	if err := os.Remove(filepath.Join(c.cacheDir(), id+cacheExt)); err != nil {
 		return fmt.Errorf("delete: %w", err)
 	}
 	return nil
+}
+
+// convoCache wraps Cache for backward compatibility
+type convoCache struct {
+	cache *Cache[[]openai.ChatCompletionMessage]
+}
+
+func newCache(dir string) *convoCache {
+	cache, err := NewCache[[]openai.ChatCompletionMessage](dir, ConversationCache)
+	if err != nil {
+		// maintain backward compatibility by handling error silently
+		return nil
+	}
+	return &convoCache{
+		cache: cache,
+	}
+}
+
+func (c *convoCache) read(id string, messages *[]openai.ChatCompletionMessage) error {
+	return c.cache.Read(id, func(r io.Reader) error {
+		return decode(r, messages)
+	})
+}
+
+func (c *convoCache) write(id string, messages *[]openai.ChatCompletionMessage) error {
+	return c.cache.Write(id, func(w io.Writer) error {
+		return encode(w, messages)
+	})
+}
+
+func (c *convoCache) delete(id string) error {
+	return c.cache.Delete(id)
 }
 
 var _ chatCompletionReceiver = &cachedCompletionStream{}
@@ -76,6 +128,7 @@ type cachedCompletionStream struct {
 }
 
 func (c *cachedCompletionStream) Close() error { return nil }
+
 func (c *cachedCompletionStream) Recv() (openai.ChatCompletionStreamResponse, error) {
 	c.m.Lock()
 	defer c.m.Unlock()
@@ -101,6 +154,7 @@ func (c *cachedCompletionStream) Recv() (openai.ChatCompletionStreamResponse, er
 	}
 
 	c.read++
+
 	return openai.ChatCompletionStreamResponse{
 		Choices: []openai.ChatCompletionStreamChoice{
 			{

--- a/config.go
+++ b/config.go
@@ -230,7 +230,7 @@ func ensureConfig() (Config, error) {
 	}
 
 	if c.CachePath == "" {
-		c.CachePath = filepath.Join(xdg.DataHome, "mods", "conversations")
+		c.CachePath = filepath.Join(xdg.DataHome, "mods")
 	}
 
 	if err := os.MkdirAll(c.CachePath, 0o700); err != nil { //nolint:mnd

--- a/config_template.yml
+++ b/config_template.yml
@@ -94,8 +94,24 @@ apis:
   copilot:
     base-url: https://api.githubcopilot.com
     models:
-      gpt-4o:
+      gpt-4o-2024-05-13:
+        aliases: ["4o-2024", "4o", "gpt-4o"]
         max-input-chars: 392000
+      gpt-4:
+        aliases: ["4"]
+        max-input-chars: 24500
+      gpt-3.5-turbo:
+        aliases: ["35t"]
+        max-input-chars: 12250
+      o1-preview-2024-09-12:
+        aliases: ["o1-preview", "o1p"]
+        max-input-chars: 128000
+      o1-mini-2024-09-12:
+        aliases: ["o1-mini", "o1m"]
+        max-input-chars: 128000
+      claude-3.5-sonnet:
+        aliases: ["claude3.5-sonnet", "sonnet-3.5", "claude-3-5-sonnet"]
+        max-input-chars: 680000
   anthropic:
     base-url: https://api.anthropic.com/v1
     api-key:

--- a/copilot.go
+++ b/copilot.go
@@ -3,11 +3,21 @@ package main
 import (
 	"encoding/json"
 	"os"
+	"path/filepath"
+	"runtime"
 )
 
 func getCopilotAuthToken() (string, error) {
-	// TODO: Windows?
-	bts, err := os.ReadFile(os.Getenv("HOME") + "/.config/github-copilot/hosts.json")
+	var sessionPath string
+	if runtime.GOOS == "windows" {
+		// C:\Users\user\AppData\Local\github-copilot\hosts.json
+		sessionPath = filepath.Join(os.Getenv("LOCALAPPDATA"), "github-copilot", "hosts.json")
+	} else {
+		// ~/.config/github-copilot/hosts.json
+		sessionPath = filepath.Join(os.Getenv("HOME"), ".config/github-copilot", "hosts.json")
+	}
+
+	bts, err := os.ReadFile(sessionPath)
 	if err != nil {
 		return "", err
 	}

--- a/copilot.go
+++ b/copilot.go
@@ -2,28 +2,148 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
+	"net/http"
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
+	"time"
 )
 
-func getCopilotAuthToken() (string, error) {
-	var sessionPath string
-	if runtime.GOOS == "windows" {
-		// C:\Users\user\AppData\Local\github-copilot\hosts.json
-		sessionPath = filepath.Join(os.Getenv("LOCALAPPDATA"), "github-copilot", "hosts.json")
-	} else {
-		// ~/.config/github-copilot/hosts.json
-		sessionPath = filepath.Join(os.Getenv("HOME"), ".config/github-copilot", "hosts.json")
+const (
+	CopilotChatAuthURL   = "https://api.github.com/copilot_internal/v2/token"
+	CopilotEditorVersion = "vscode/1.95.3"
+	CopilotUserAgent     = "curl/7.81.0" // Necessay to bypass the user-agent check
+)
+
+type CopilotAccessToken struct {
+	Token     string `json:"token"`
+	ExpiresAt int64  `json:"expires_at"`
+	Endpoints struct {
+		API           string `json:"api"` // Can change in Github Enterprise instances
+		OriginTracker string `json:"origin-tracker"`
+		Proxy         string `json:"proxy"`
+		Telemetry     string `json:"telemetry"`
+	} `json:"endpoints"`
+	ErrorDetails *struct {
+		URL            string `json:"url,omitempty"`
+		Message        string `json:"message,omitempty"`
+		Title          string `json:"title,omitempty"`
+		NotificationID string `json:"notification_id,omitempty"`
+	} `json:"error_details,omitempty"`
+}
+
+type CopilotHTTPClient struct {
+	client      *http.Client
+	AccessToken *CopilotAccessToken
+}
+
+func NewCopilotHTTPClient() *CopilotHTTPClient {
+	return &CopilotHTTPClient{
+		client: &http.Client{},
+	}
+}
+
+func (c *CopilotHTTPClient) Do(req *http.Request) (*http.Response, error) {
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Editor-Version", CopilotEditorVersion)
+	req.Header.Set("User-Agent", CopilotUserAgent)
+
+	var isTokenExpired bool = c.AccessToken != nil && c.AccessToken.ExpiresAt < time.Now().Unix()
+
+	if c.AccessToken == nil || isTokenExpired {
+		// Use the base http.Client for token requests to avoid recursion
+		accessToken, err := getCopilotAccessToken(c.client)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get access token: %w", err)
+		}
+
+		c.AccessToken = &accessToken
 	}
 
-	bts, err := os.ReadFile(sessionPath)
+	return c.client.Do(req)
+}
+
+func getCopilotRefreshToken() (string, error) {
+	configPath := filepath.Join(os.Getenv("HOME"), ".config/github-copilot")
+	if runtime.GOOS == "windows" {
+		configPath = filepath.Join(os.Getenv("LOCALAPPDATA"), "github-copilot")
+	}
+
+	// Check both possible config file locations
+	configFiles := []string{
+		filepath.Join(configPath, "hosts.json"),
+		filepath.Join(configPath, "apps.json"),
+	}
+
+	// Try to get token from config files
+	for _, path := range configFiles {
+		token, err := extractCopilotTokenFromFile(path)
+		if err == nil && token != "" {
+			return token, nil
+		}
+	}
+
+	return "", fmt.Errorf("no token found in %s", strings.Join(configFiles, ", "))
+}
+
+func extractCopilotTokenFromFile(path string) (string, error) {
+	bytes, err := os.ReadFile(path)
 	if err != nil {
 		return "", err
 	}
-	hosts := map[string]map[string]string{}
-	if err := json.Unmarshal(bts, &hosts); err != nil {
+
+	var config map[string]json.RawMessage
+	if err := json.Unmarshal(bytes, &config); err != nil {
 		return "", err
 	}
-	return hosts["github.com"]["oauth_token"], nil
+
+	for key, value := range config {
+		if key == "github.com" || strings.HasPrefix(key, "github.com:") {
+			var tokenData map[string]string
+			if err := json.Unmarshal(value, &tokenData); err != nil {
+				continue
+			}
+			if token, exists := tokenData["oauth_token"]; exists {
+				return token, nil
+			}
+		}
+	}
+
+	return "", fmt.Errorf("no token found in %s", path)
+}
+
+func getCopilotAccessToken(client *http.Client) (CopilotAccessToken, error) {
+	refreshToken, err := getCopilotRefreshToken()
+	if err != nil {
+		return CopilotAccessToken{}, fmt.Errorf("failed to get refresh token: %w", err)
+	}
+
+	tokenReq, err := http.NewRequest(http.MethodGet, CopilotChatAuthURL, nil)
+	if err != nil {
+		return CopilotAccessToken{}, fmt.Errorf("failed to create token request: %w", err)
+	}
+
+	tokenReq.Header.Set("Authorization", "token "+refreshToken)
+	tokenReq.Header.Set("Accept", "application/json")
+	tokenReq.Header.Set("Editor-Version", CopilotEditorVersion)
+	tokenReq.Header.Set("User-Agent", CopilotUserAgent)
+
+	tokenResp, err := client.Do(tokenReq)
+	if err != nil {
+		return CopilotAccessToken{}, fmt.Errorf("failed to get access token: %w", err)
+	}
+	defer tokenResp.Body.Close()
+
+	var tokenResponse CopilotAccessToken
+	if err := json.NewDecoder(tokenResp.Body).Decode(&tokenResponse); err != nil {
+		return CopilotAccessToken{}, fmt.Errorf("failed to decode token response: %w", err)
+	}
+
+	if tokenResponse.ErrorDetails != nil {
+		return CopilotAccessToken{}, fmt.Errorf("token error: %s", tokenResponse.ErrorDetails.Message)
+	}
+
+	return tokenResponse, nil
 }

--- a/main.go
+++ b/main.go
@@ -310,7 +310,7 @@ func main() {
 	}
 
 	cache = newCache(config.CachePath)
-	db, err = openDB(filepath.Join(config.CachePath, "mods.db"))
+	db, err = openDB(filepath.Join(config.CachePath, "conversations", "mods.db"))
 	if err != nil {
 		handleError(modsError{err, "Could not open database."})
 		os.Exit(1)

--- a/mods.go
+++ b/mods.go
@@ -357,12 +357,17 @@ func (m *Mods) startCompletionCmd(content string) tea.Cmd {
 				cfg.User = api.User
 			}
 		case "copilot":
-			token, err := getCopilotAuthToken()
+			copilotHttpClient := NewCopilotHTTPClient()
+			accessToken, err := getCopilotAccessToken(copilotHttpClient.client)
 			if err != nil {
 				return modsError{err, "Copilot authentication failed"}
 			}
-			ccfg = openai.DefaultConfig(token)
-			ccfg.BaseURL = api.BaseURL
+
+			ccfg = openai.DefaultConfig(accessToken.Token)
+			ccfg.HTTPClient = copilotHttpClient
+			ccfg.HTTPClient.(*CopilotHTTPClient).AccessToken = &accessToken
+			ccfg.BaseURL = ordered.First(api.BaseURL, accessToken.Endpoints.API)
+
 		default:
 			key, err := m.ensureKey(api, "OPENAI_API_KEY", "https://platform.openai.com/account/api-keys")
 			if err != nil {


### PR DESCRIPTION
### Description 
For my usage which primarily uses Copilot, this change made a huge difference in performance - reducing about ~2 seconds for each request by caching the access tokens.

Not sure if this is the direction you want to go, but I found it very helpful for my workflow.
Let me know if you'd like any changes - happy to update!

### Changes 

1. Convert existing cache to generic Cache[T] type
   - Split into "conversations" and "temporary" cache types
   - Add better error handling and directory management
   - Improve type safety with generics

2. Add ExpiringCache implementation
   - Support for time-based cache expiration
   - Automatic cleanup of expired entries
   - Used for caching Copilot access tokens

```
$HOME/user/.local/share/mods
.
├── cache
│   └── copilot.1734276998
└── conversations
    ├── 0dbcdaae5bf314e06a9b47bf513e4ab69483761e.gob
    ├── 14a5b9133e384ae4f42c3a49756f6be9703c6982.gob
    ├── 35588af9aeec76b98ee8e4776e6be751e9528417.gob
    └── mods.db
```

**Note:** This PR builds on #406 and should be merged after it.

