### PR TITLE
feat(config): add gemini-2-flash models and update aliases

### DIFF
--- a/config_template.yml
+++ b/config_template.yml
@@ -155,13 +155,20 @@ apis:
       command-r:
         max-input-chars: 128000
   google:
-    models:
+    models: # https://ai.google.dev/gemini-api/docs/models/gemini
       gemini-1.5-pro-latest:
-        aliases: ["gemini"]
+        aliases: ["gmp", "gemini", "gemini-1.5-pro"]
         max-input-chars: 392000
       gemini-1.5-flash-latest:
-        aliases: ["flash"]
+        aliases: ["gmf", "flash", "gemini-1.5-flash"]
         max-input-chars: 392000
+      gemini-2.0-flash-001:
+        aliases: ["gm2f", "flash-2", "gemini-2-flash"]
+        max-input-chars: 4194304
+      gemini-2.0-flash-lite:
+        aliases: ["gm2fl", "flash-2-lite", "gemini-2-flash-lite"]
+        max-input-chars: 4194304
+
   ollama:
     base-url: http://localhost:11434/api
     models: # https://ollama.com/library

--- a/config_template.yml
+++ b/config_template.yml
@@ -129,6 +129,9 @@ apis:
       o3-mini:
         aliases: ["o3m", "o3-mini"]
         max-input-chars: 128000
+      gemini-2.0-flash-001:
+        aliases: ["gm2f", "flash-2", "gemini-2-flash"]
+        max-input-chars: 4194304
   anthropic:
     base-url: https://api.anthropic.com/v1
     api-key:


### PR DESCRIPTION
### For GitHub Copilot Users

For now, it is necessary to enable the model in your GitHub config. Otherwise, it will say you don't have permission to use the model.

You can find this option under "Settings > Copilot" (https://github.com/settings/copilot).

> ![Screenshot_2025-02-07_20-30-27](https://github.com/user-attachments/assets/734b33f1-eb24-4647-9f34-c46d5a125778)

### References

**GitHub Announcement**
https://github.blog/changelog/2025-02-05-google-gemini-2-0-flash-is-now-available-to-all-copilot-users-in-public-preview/

**Google Models reference API**
https://ai.google.dev/gemini-api/docs/models/gemini

**Request**
![image](https://github.com/user-attachments/assets/0261a291-50de-46a2-aee7-6102b38e28b6)
