### PR TITLE
fix: remove duplicate model key `o3-mini` from config template

### DIFF
--- a/config_template.yml
+++ b/config_template.yml
@@ -94,10 +94,7 @@ apis:
         max-input-chars: 12250
         fallback:
       o1:
-        aliases: ["o1-preview"]
-        max-input-chars: 200000
-      o3-mini:
-        aliases: ["o1-preview"]
+        aliases: ["o1"]
         max-input-chars: 200000
       o1-preview:
         aliases: ["o1-preview"]
@@ -107,7 +104,7 @@ apis:
         max-input-chars: 128000
       o3-mini:
         aliases: ["o3m", "o3-mini"]
-        max-input-chars: 128000
+        max-input-chars: 200000
   copilot:
     base-url: https://api.githubcopilot.com
     models:


### PR DESCRIPTION
### The commit 364c41969fb2c91f5532e613524dccdc2d2c869b duplicates the `o3-mini` key in the config template, which causes an error when loading the configuration file after resetting settings to default

### To reproduce: 

1. Reset your settings using the command `mods --reset-settings`. 

Then subsequent commands should be met with the following error:

<img width="539" alt="image" src="https://github.com/user-attachments/assets/56011d61-a7e0-4baa-b99b-90483d477722" />

### Changes made:

1. Removed the duplicate `o3-mini` key
2. Replaced the duplicate alias `o1-preview` from the o1 model with just `o1`
3. Updated the max-input-chars for `o3-mini` from `128000` to the correct value `200000` per OpenAI docs