### PR TITLE
Fix Perplexity API Role Compatibility (Issue #448)

### DIFF
--- a/stream.go
+++ b/stream.go
@@ -21,16 +21,19 @@ func (m *Mods) createOpenAIStream(content string, ccfg openai.ClientConfig, mod 
 		return err
 	}
 
-	// Remap system messages to user messages due to beta limitations
-	messages := []openai.ChatCompletionMessage{}
-	for _, message := range m.messages {
-		if message.Role == openai.ChatMessageRoleSystem {
-			messages = append(messages, openai.ChatCompletionMessage{
-				Role:    openai.ChatMessageRoleUser,
-				Content: message.Content,
-			})
-		} else {
-			messages = append(messages, message)
+	// o1-preview and o1-mini don't support system messages
+	messages := m.messages
+	if mod.Name == "o1-preview" || mod.Name == "o1-mini" {
+		messages = []openai.ChatCompletionMessage{}
+		for _, message := range m.messages {
+			if message.Role == openai.ChatMessageRoleSystem {
+				messages = append(messages, openai.ChatCompletionMessage{
+					Role:    openai.ChatMessageRoleUser,
+					Content: message.Content,
+				})
+			} else {
+				messages = append(messages, message)
+			}
 		}
 	}
 

--- a/stream.go
+++ b/stream.go
@@ -21,25 +21,19 @@ func (m *Mods) createOpenAIStream(content string, ccfg openai.ClientConfig, mod 
 		return err
 	}
 
-	// o1-preview and o1-mini don't support system messages
-	messages := m.messages
+	// Remap System role to User for o1-preview and o1-mini as they don't support system messages
 	if mod.Name == "o1-preview" || mod.Name == "o1-mini" {
-		messages = []openai.ChatCompletionMessage{}
-		for _, message := range m.messages {
-			if message.Role == openai.ChatMessageRoleSystem {
-				messages = append(messages, openai.ChatCompletionMessage{
-					Role:    openai.ChatMessageRoleUser,
-					Content: message.Content,
-				})
-			} else {
-				messages = append(messages, message)
+		for i, message := range m.messages {
+			if message.Role != openai.ChatMessageRoleSystem {
+				continue
 			}
+			m.messages[i].Role = openai.ChatMessageRoleUser
 		}
 	}
 
 	req := openai.ChatCompletionRequest{
 		Model:    mod.Name,
-		Messages: messages,
+		Messages: m.messages,
 		Stream:   true,
 		User:     cfg.User,
 	}


### PR DESCRIPTION
# Fix Perplexity API Role Compatibility (Issue #448)
This fix maintains compatibility with legacy o1 models while solving the Perplexity error.

## The Problem
A previous update (commit e5e4bdd) added support for o1-preview and o1-mini models by converting system messages to user messages. However, this breaks Perplexity models because their API doesn't allow multiple consecutive messages with the same role.

## How to See the Issue
Try this command and you'll see an error:
```
mods --model llama-3.1-sonar-small-128k-online --role shell list all files
```

## Solution
- Only remap system messages for the two models that need it (o1-preview and o1-mini)
- Keep the original message roles for all other models that go through the function `createOpenAIStream (stream.go)`

## Note 
The system message remapping is not needed for these models, which handle system messages correctly without modification:
 - o1
 - o3-mini
 - gpt-4.5-preview