### PR TITLE
fix: only read from stdin if there is data to read

### DIFF
--- a/main.go
+++ b/main.go
@@ -412,7 +412,7 @@ func maybeWriteMemProfile() {
 func handleError(err error) {
 	maybeWriteMemProfile()
 	// exhaust stdin
-	if !isInputTTY() {
+	if !isInputTTY() && shouldReadInput() {
 		_, _ = io.ReadAll(os.Stdin)
 	}
 

--- a/mods.go
+++ b/mods.go
@@ -608,7 +608,7 @@ func (m *Mods) findReadID(in string) (*Conversation, error) {
 }
 
 func (m *Mods) readStdinCmd() tea.Msg {
-	if !isInputTTY() {
+	if !isInputTTY() && shouldReadInput() {
 		reader := bufio.NewReader(os.Stdin)
 		stdinBytes, err := io.ReadAll(reader)
 		if err != nil {

--- a/term.go
+++ b/term.go
@@ -12,6 +12,11 @@ var isInputTTY = OnceValue(func() bool {
 	return isatty.IsTerminal(os.Stdin.Fd())
 })
 
+var shouldReadInput = OnceValue(func() bool {
+	stat, _ := os.Stdin.Stat()
+	return stat.Size() > 0
+})
+
 var isOutputTTY = OnceValue(func() bool {
 	return isatty.IsTerminal(os.Stdout.Fd())
 })


### PR DESCRIPTION
Always check if there is data to read from stdin before reading from it. Otherwise, the program will hang and wait for input or EOT.