### PR TITLE
Add Pixi installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ Use a package manager:
 # macOS or Linux
 brew install charmbracelet/tap/mods
 
+# macOS, Linux or Windows (with Pixi)
+pixi global install mods
+
 # Windows (with Winget)
 winget install charmbracelet.mods
 


### PR DESCRIPTION
This PR adds instruction on how to install `mods` with [Pixi](https://pixi.sh/latest/) (works for Linux, macOS, and Windows).