### PR TITLE
feat(copilot): adds github copilot login support

### DIFF
--- a/copilot.go
+++ b/copilot.go
@@ -119,8 +119,9 @@ func copilotLogin(client *http.Client, configPath string) (string, error) {
 
 	deviceCodeResp.UserCode = data.Get("user_code")
 	deviceCodeResp.ExpiresIn, _ = strconv.Atoi(data.Get("expires_in"))
+	deviceCodeResp.Interval, _ = strconv.Atoi(data.Get("interval"))
 	deviceCodeResp.DeviceCode = data.Get("device_code")
-	deviceCodeResp.VerificationUri = data.Get("")
+	deviceCodeResp.VerificationUri = data.Get("verification_uri")
 
 	fmt.Printf("Please go to %s and enter the code %s\n", deviceCodeResp.VerificationUri, deviceCodeResp.UserCode)
 	saveCopilotRefreshToken(client, deviceCodeResp.DeviceCode, deviceCodeResp.Interval, deviceCodeResp.ExpiresIn)

--- a/copilot.go
+++ b/copilot.go
@@ -315,8 +315,6 @@ func getCopilotOAuthToken(client *http.Client) (string, error) {
 	}
 
 	return "", fmt.Errorf(token)
-
-	return "", fmt.Errorf("no token found in %s", strings.Join(configFiles, ", "))
 }
 
 func extractCopilotTokenFromFile(path string) (string, error) {


### PR DESCRIPTION
As mentioned in #426, currently, we require an external program to generate the Github Copilot oAuthToken.
This PR adds all necessary structures to do this first login within mods.

### How to test

1. Backup and remove your oAuthToken (`~/.config/github-copilot`)
2. Remove the cached token (~/.local/share/mods/temp/)
3. Try to run a new generation using mods
4. Following the instructions using the DeviceCode authentication flow (it will show in your terminal)

> It will automatically ask for login and poll for the authToken every 5 seconds (defined by the API) and perform the generation afterwards

### PR Summary

#### Authentication Refactor:

* Added new constants for device code and token URLs and the client ID (`copilot.go`).
* Introduced new data structures for handling device code and token responses (`CopilotDeviceCodeResponse`, `CopilotDeviceTokenResponse`, `CopilotFailedRequestResponse`, `copilotGithubOAuthTokenWrapper`, `copilotOAuthToken`) (`copilot.go`).

#### New Functions:

* Added `copilotLogin` function to initiate device code authentication and fetch the OAuth token (`copilot.go`).
* Added `fetchCopilotRefreshToken` function to poll for the OAuth token using the device code (`copilot.go`).
* Added `saveCopilotOAuthToken` and `copilotRegisterApp` functions to save the OAuth token and register the app version (`copilot.go`).

#### Refactoring Existing Functions:

* Modified `getCopilotRefreshToken` to use the new `copilotLogin` function for obtaining the OAuth token (`copilot.go`).
* Updated `getCopilotAccessToken` to fetch the OAuth token instead of the refresh token (`copilot.go`).