### PR TITLE
fix: remove final dot to fix link to grab api key

### DIFF
--- a/mods.go
+++ b/mods.go
@@ -445,7 +445,7 @@ func (m Mods) ensureKey(api API, defaultEnv, docsURL string) (string, error) {
 			m.Styles.InlineCode.Render("mods --settings"),
 		),
 		err: newUserErrorf(
-			"You can grab one at %s.",
+			"You can grab one at %s",
 			m.Styles.Link.Render(docsURL),
 		),
 	}


### PR DESCRIPTION
Removing the final ending dot because it it really appended to the link when on hover open it.

<img width="652" alt="Screenshot 2025-05-15 at 17 21 39" src="https://github.com/user-attachments/assets/5475db02-c5e1-4b43-b61e-611f3e7f6f07" />
