### PR TITLE
fix: ollama returns io.EOF on Done chunk

### DIFF
--- a/ollama.go
+++ b/ollama.go
@@ -213,7 +213,7 @@ func (stream *ollamaStreamReader) processLines() (openai.ChatCompletionStreamRes
 		}
 
 		if chunk.Done {
-			return openai.ChatCompletionStreamResponse{}, nil
+			return openai.ChatCompletionStreamResponse{}, io.EOF
 		}
 
 		if chunk.Message.Content == "" {


### PR DESCRIPTION
### Describe your changes

Returning a zero-value Error response on Done caused consumer of Recv() to process an extra, empty/duplicated message. This previously resulted in printing of things like 'hello' from the LLM as 'helloo' in mods. Done now signals end-of-stream as expected.

### Related issue/discussion:

N/A - I can open if desired. Ollama streams currently print the last chunk multiple times (at least for me, locally):

```
$ mods --version
mods version v1.7.0 (c4461d4)
$ mods "Hi there"

  Hi! 😊

  It's nice to hear from you! What can I do for you today??
$ cat my-jira | mods "Is this epic groomed well?"

NoNo

$ mods --continue-last "what's wrong with the summary?"

Too verbose verbose verbose
```

### Checklist before requesting a review

- [ ] I have read `CONTRIBUTING.md`
  - There is no such file in this repo - it was the first thing I tried to find :( LMK if anything here is not in accordance with this community's standards.
- [x] I have performed a self-review of my code

### If this is a feature

N/A - bugfix

- [ ] I have created a discussion
- [ ] A project maintainer has approved this feature request. Link to comment:
