### PR TITLE
feat: better handle api

### DIFF
--- a/config.go
+++ b/config.go
@@ -29,7 +29,7 @@ const (
 )
 
 var help = map[string]string{
-	"api":               "OpenAI compatible REST API (openai, localai).",
+	"api":               "OpenAI compatible REST API (openai, localai, anthropic, ...).",
 	"apis":              "Aliases and endpoints for OpenAI compatible REST API.",
 	"http-proxy":        "HTTP proxy to use for API requests.",
 	"model":             "Default model (gpt-3.5-turbo, gpt-4, ggml-gpt4all-j...).",
@@ -132,6 +132,7 @@ func (ft *FormatText) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 // Config holds the main configuration and is mapped to the YAML settings file.
 type Config struct {
+	API                 string     `yaml:"default-api" env:"API"`
 	Model               string     `yaml:"default-model" env:"MODEL"`
 	Format              bool       `yaml:"format" env:"FORMAT"`
 	FormatText          FormatText `yaml:"format-text"`
@@ -159,8 +160,6 @@ type Config struct {
 	System              string     `yaml:"system"`
 	Role                string     `yaml:"role" env:"ROLE"`
 	AskModel            bool
-	API                 string
-	Models              map[string]Model
 	Roles               map[string][]string
 	ShowHelp            bool
 	ResetSettings       bool
@@ -208,25 +207,6 @@ func ensureConfig() (Config, error) {
 	if err := yaml.Unmarshal(content, &c); err != nil {
 		return c, modsError{err, "Could not parse settings file."}
 	}
-	ms := make(map[string]Model)
-	for _, api := range c.APIs {
-		for mk, mv := range api.Models {
-			mv.Name = mk
-			mv.API = api.Name
-			// only set the model key and aliases if they haven't already been used
-			_, ok := ms[mk]
-			if !ok {
-				ms[mk] = mv
-			}
-			for _, a := range mv.Aliases {
-				_, ok := ms[a]
-				if !ok {
-					ms[a] = mv
-				}
-			}
-		}
-	}
-	c.Models = ms
 
 	if err := env.ParseWithOptions(&c, env.Options{Prefix: "MODS_"}); err != nil {
 		return c, modsError{err, "Could not parse environment into settings file."}

--- a/config_template.yml
+++ b/config_template.yml
@@ -1,3 +1,5 @@
+# {{ index .Help "api" }}
+default-api: openai
 # {{ index .Help "model" }}
 default-model: gpt-4o
 # {{ index .Help "format-text" }}

--- a/db_test.go
+++ b/db_test.go
@@ -30,7 +30,7 @@ func TestConvoDB(t *testing.T) {
 	t.Run("save", func(t *testing.T) {
 		db := testDB(t)
 
-		require.NoError(t, db.Save(testid, "message 1", "gpt-4o"))
+		require.NoError(t, db.Save(testid, "message 1", "openai", "gpt-4o"))
 
 		convo, err := db.Find("df31")
 		require.NoError(t, err)
@@ -44,20 +44,20 @@ func TestConvoDB(t *testing.T) {
 
 	t.Run("save no id", func(t *testing.T) {
 		db := testDB(t)
-		require.Error(t, db.Save("", "message 1", "gpt-4o"))
+		require.Error(t, db.Save("", "message 1", "openai", "gpt-4o"))
 	})
 
 	t.Run("save no message", func(t *testing.T) {
 		db := testDB(t)
-		require.Error(t, db.Save(newConversationID(), "", "gpt-4o"))
+		require.Error(t, db.Save(newConversationID(), "", "openai", "gpt-4o"))
 	})
 
 	t.Run("update", func(t *testing.T) {
 		db := testDB(t)
 
-		require.NoError(t, db.Save(testid, "message 1", "gpt-4o"))
+		require.NoError(t, db.Save(testid, "message 1", "openai", "gpt-4o"))
 		time.Sleep(100 * time.Millisecond)
-		require.NoError(t, db.Save(testid, "message 2", "gpt-4o"))
+		require.NoError(t, db.Save(testid, "message 2", "openai", "gpt-4o"))
 
 		convo, err := db.Find("df31")
 		require.NoError(t, err)
@@ -72,7 +72,7 @@ func TestConvoDB(t *testing.T) {
 	t.Run("find head single", func(t *testing.T) {
 		db := testDB(t)
 
-		require.NoError(t, db.Save(testid, "message 2", "gpt-4o"))
+		require.NoError(t, db.Save(testid, "message 2", "openai", "gpt-4o"))
 
 		head, err := db.FindHEAD()
 		require.NoError(t, err)
@@ -83,10 +83,10 @@ func TestConvoDB(t *testing.T) {
 	t.Run("find head multiple", func(t *testing.T) {
 		db := testDB(t)
 
-		require.NoError(t, db.Save(testid, "message 2", "gpt-4o"))
+		require.NoError(t, db.Save(testid, "message 2", "openai", "gpt-4o"))
 		time.Sleep(time.Millisecond * 100)
 		nextConvo := newConversationID()
-		require.NoError(t, db.Save(nextConvo, "another message", "gpt-4o"))
+		require.NoError(t, db.Save(nextConvo, "another message", "openai", "gpt-4o"))
 
 		head, err := db.FindHEAD()
 		require.NoError(t, err)
@@ -101,8 +101,8 @@ func TestConvoDB(t *testing.T) {
 	t.Run("find by title", func(t *testing.T) {
 		db := testDB(t)
 
-		require.NoError(t, db.Save(newConversationID(), "message 1", "gpt-4o"))
-		require.NoError(t, db.Save(testid, "message 2", "gpt-4o"))
+		require.NoError(t, db.Save(newConversationID(), "message 1", "openai", "gpt-4o"))
+		require.NoError(t, db.Save(testid, "message 2", "openai", "gpt-4o"))
 
 		convo, err := db.Find("message 2")
 		require.NoError(t, err)
@@ -112,7 +112,7 @@ func TestConvoDB(t *testing.T) {
 
 	t.Run("find match nothing", func(t *testing.T) {
 		db := testDB(t)
-		require.NoError(t, db.Save(testid, "message 1", "gpt-4o"))
+		require.NoError(t, db.Save(testid, "message 1", "openai", "gpt-4o"))
 		_, err := db.Find("message")
 		require.ErrorIs(t, err, errNoMatches)
 	})
@@ -120,8 +120,8 @@ func TestConvoDB(t *testing.T) {
 	t.Run("find match many", func(t *testing.T) {
 		db := testDB(t)
 		const testid2 = "df31ae23ab9b75b5641c2f846c571000edc71315"
-		require.NoError(t, db.Save(testid, "message 1", "gpt-4o"))
-		require.NoError(t, db.Save(testid2, "message 2", "gpt-4o"))
+		require.NoError(t, db.Save(testid, "message 1", "openai", "gpt-4o"))
+		require.NoError(t, db.Save(testid2, "message 2", "openai", "gpt-4o"))
 		_, err := db.Find("df31ae")
 		require.ErrorIs(t, err, errManyMatches)
 	})
@@ -129,7 +129,7 @@ func TestConvoDB(t *testing.T) {
 	t.Run("delete", func(t *testing.T) {
 		db := testDB(t)
 
-		require.NoError(t, db.Save(testid, "message 1", "gpt-4o"))
+		require.NoError(t, db.Save(testid, "message 1", "openai", "gpt-4o"))
 		require.NoError(t, db.Delete(newConversationID()))
 
 		list, err := db.List()
@@ -152,8 +152,8 @@ func TestConvoDB(t *testing.T) {
 		const title1 = "some title"
 		const testid2 = "6c33f71694bf41a18c844a96d1f62f153e5f6f44"
 		const title2 = "football teams"
-		require.NoError(t, db.Save(testid1, title1, "gpt-4o"))
-		require.NoError(t, db.Save(testid2, title2, "gpt-4o"))
+		require.NoError(t, db.Save(testid1, title1, "openai", "gpt-4o"))
+		require.NoError(t, db.Save(testid2, title2, "openai", "gpt-4o"))
 
 		results, err := db.Completions("f")
 		require.NoError(t, err)

--- a/main.go
+++ b/main.go
@@ -627,6 +627,9 @@ func makeOptions(conversations []Conversation) []huh.Option[string] {
 		if c.Model != nil {
 			right += stdoutStyles().Comment.Render(*c.Model)
 		}
+		if c.API != nil {
+			right += stdoutStyles().Comment.Render(" (" + *c.API + ")")
+		}
 		opts = append(opts, huh.NewOption(left+" "+right, c.ID))
 	}
 	return opts
@@ -706,7 +709,7 @@ func saveConversation(mods *Mods) error {
 			stderrStyles().InlineCode.Render("NO_CACHE"),
 		)}
 	}
-	if err := db.Save(id, title, config.Model); err != nil {
+	if err := db.Save(id, title, config.API, config.Model); err != nil {
 		_ = cache.delete(id) // remove leftovers
 		return modsError{err, fmt.Sprintf(
 			"There was a problem writing %s to the cache. Use %s / %s to disable it.",
@@ -753,8 +756,9 @@ func askInfo() error {
 
 	if config.ContinueLast {
 		found, err := db.FindHEAD()
-		if err == nil && found != nil && found.Model != nil {
+		if err == nil && found != nil && found.Model != nil && found.API != nil {
 			config.Model = *found.Model
+			config.API = *found.API
 		}
 	}
 

--- a/mods.go
+++ b/mods.go
@@ -6,12 +6,14 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"math"
 	"net/http"
 	"net/url"
 	"os"
 	"os/exec"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -113,6 +115,7 @@ func (m *Mods) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.Config.cacheWriteToID = msg.WriteID
 		m.Config.cacheWriteToTitle = msg.Title
 		m.Config.cacheReadFromID = msg.ReadID
+		m.Config.API = msg.API
 		m.Config.Model = msg.Model
 
 		if !m.Config.Quiet {
@@ -259,9 +262,6 @@ func (m *Mods) startCompletionCmd(content string) tea.Cmd {
 	}
 
 	return func() tea.Msg {
-		var ok bool
-		var mod Model
-		var api API
 		var ccfg openai.ClientConfig
 		var accfg AnthropicClientConfig
 		var cccfg CohereClientConfig
@@ -269,30 +269,10 @@ func (m *Mods) startCompletionCmd(content string) tea.Cmd {
 		var gccfg GoogleClientConfig
 
 		cfg := m.Config
-		mod, ok = cfg.Models[cfg.Model]
-		if !ok {
-			if cfg.API == "" {
-				return modsError{
-					reason: fmt.Sprintf(
-						"Model %s is not in the settings file.",
-						m.Styles.InlineCode.Render(cfg.Model),
-					),
-					err: newUserErrorf(
-						"Please specify an API endpoint with %s or configure the model in the settings: %s",
-						m.Styles.InlineCode.Render("--api"),
-						m.Styles.InlineCode.Render("mods --settings"),
-					),
-				}
-			}
-			mod.Name = cfg.Model
-			mod.API = cfg.API
-			mod.MaxChars = cfg.MaxInputChars
-		}
-		for _, a := range cfg.APIs {
-			if mod.API == a.Name {
-				api = a
-				break
-			}
+
+		api, mod, err := m.resolveModel(cfg)
+		if err != nil {
+			return err
 		}
 		if api.Name == "" {
 			eps := make([]string, 0)
@@ -534,7 +514,7 @@ func (m *Mods) receiveCompletionStreamCmd(msg completionOutput) tea.Cmd {
 }
 
 type cacheDetailsMsg struct {
-	WriteID, Title, ReadID, Model string
+	WriteID, Title, ReadID, API, Model string
 }
 
 func (m *Mods) findCacheOpsDetails() tea.Cmd {
@@ -544,6 +524,7 @@ func (m *Mods) findCacheOpsDetails() tea.Cmd {
 		writeID := ordered.First(m.Config.Title, m.Config.Continue)
 		title := writeID
 		model := config.Model
+		api := config.API
 
 		if readID != "" || continueLast || m.Config.ShowLast {
 			found, err := m.findReadID(readID)
@@ -555,8 +536,9 @@ func (m *Mods) findCacheOpsDetails() tea.Cmd {
 			}
 			if found != nil {
 				readID = found.ID
-				if found.Model != nil {
+				if found.Model != nil && found.API != nil {
 					model = *found.Model
+					api = *found.API
 				}
 			}
 		}
@@ -584,6 +566,7 @@ func (m *Mods) findCacheOpsDetails() tea.Cmd {
 			WriteID: writeID,
 			Title:   title,
 			ReadID:  readID,
+			API:     api,
 			Model:   model,
 		}
 	}
@@ -734,8 +717,53 @@ func cutPrompt(msg, prompt string) string {
 
 func increaseIndent(s string) string {
 	lines := strings.Split(s, "\n")
-	for i := 0; i < len(lines); i++ {
+	for i := range lines {
 		lines[i] = "\t" + lines[i]
 	}
 	return strings.Join(lines, "\n")
+}
+
+func (m *Mods) resolveModel(cfg *Config) (API, Model, error) {
+	for _, api := range cfg.APIs {
+		if api.Name != cfg.API && cfg.API != "" {
+			continue
+		}
+		for name, mod := range api.Models {
+			if name == cfg.Model || slices.Contains(mod.Aliases, cfg.Model) {
+				cfg.Model = name
+				break
+			}
+		}
+		mod, ok := api.Models[cfg.Model]
+		if ok {
+			mod.Name = cfg.Model
+			mod.API = cfg.API
+			return api, mod, nil
+		}
+		if cfg.API != "" {
+			return API{}, Model{}, modsError{
+				err: newUserErrorf(
+					"Available models are: %s",
+					strings.Join(slices.Collect(maps.Keys(api.Models)), ", "),
+				),
+				reason: fmt.Sprintf(
+					"The API endpoint %s does not contain the model %s",
+					m.Styles.InlineCode.Render(cfg.API),
+					m.Styles.InlineCode.Render(cfg.Model),
+				),
+			}
+		}
+	}
+
+	return API{}, Model{}, modsError{
+		reason: fmt.Sprintf(
+			"Model %s is not in the settings file.",
+			m.Styles.InlineCode.Render(cfg.Model),
+		),
+		err: newUserErrorf(
+			"Please specify an API endpoint with %s or configure the model in the settings: %s",
+			m.Styles.InlineCode.Render("--api"),
+			m.Styles.InlineCode.Render("mods --settings"),
+		),
+	}
 }

--- a/mods_test.go
+++ b/mods_test.go
@@ -28,7 +28,7 @@ func TestFindCacheOpsDetails(t *testing.T) {
 	t.Run("show id", func(t *testing.T) {
 		mods := newMods(t)
 		id := newConversationID()
-		require.NoError(t, mods.db.Save(id, "message", "gpt-4"))
+		require.NoError(t, mods.db.Save(id, "message", "openai", "gpt-4"))
 		mods.Config.Show = id[:8]
 		msg := mods.findCacheOpsDetails()()
 		dets := msg.(cacheDetailsMsg)
@@ -38,7 +38,7 @@ func TestFindCacheOpsDetails(t *testing.T) {
 	t.Run("show title", func(t *testing.T) {
 		mods := newMods(t)
 		id := newConversationID()
-		require.NoError(t, mods.db.Save(id, "message 1", "gpt-4"))
+		require.NoError(t, mods.db.Save(id, "message 1", "openai", "gpt-4"))
 		mods.Config.Show = "message 1"
 		msg := mods.findCacheOpsDetails()()
 		dets := msg.(cacheDetailsMsg)
@@ -48,7 +48,7 @@ func TestFindCacheOpsDetails(t *testing.T) {
 	t.Run("continue id", func(t *testing.T) {
 		mods := newMods(t)
 		id := newConversationID()
-		require.NoError(t, mods.db.Save(id, "message", "gpt-4"))
+		require.NoError(t, mods.db.Save(id, "message", "openai", "gpt-4"))
 		mods.Config.Continue = id[:5]
 		mods.Config.Prefix = "prompt"
 		msg := mods.findCacheOpsDetails()()
@@ -60,7 +60,7 @@ func TestFindCacheOpsDetails(t *testing.T) {
 	t.Run("continue with no prompt", func(t *testing.T) {
 		mods := newMods(t)
 		id := newConversationID()
-		require.NoError(t, mods.db.Save(id, "message 1", "gpt-4"))
+		require.NoError(t, mods.db.Save(id, "message 1", "openai", "gpt-4"))
 		mods.Config.ContinueLast = true
 		msg := mods.findCacheOpsDetails()()
 		dets := msg.(cacheDetailsMsg)
@@ -72,7 +72,7 @@ func TestFindCacheOpsDetails(t *testing.T) {
 	t.Run("continue title", func(t *testing.T) {
 		mods := newMods(t)
 		id := newConversationID()
-		require.NoError(t, mods.db.Save(id, "message 1", "gpt-4"))
+		require.NoError(t, mods.db.Save(id, "message 1", "openai", "gpt-4"))
 		mods.Config.Continue = "message 1"
 		mods.Config.Prefix = "prompt"
 		msg := mods.findCacheOpsDetails()()
@@ -84,7 +84,7 @@ func TestFindCacheOpsDetails(t *testing.T) {
 	t.Run("continue last", func(t *testing.T) {
 		mods := newMods(t)
 		id := newConversationID()
-		require.NoError(t, mods.db.Save(id, "message 1", "gpt-4"))
+		require.NoError(t, mods.db.Save(id, "message 1", "openai", "gpt-4"))
 		mods.Config.ContinueLast = true
 		mods.Config.Prefix = "prompt"
 		msg := mods.findCacheOpsDetails()()
@@ -97,7 +97,7 @@ func TestFindCacheOpsDetails(t *testing.T) {
 	t.Run("continue last with name", func(t *testing.T) {
 		mods := newMods(t)
 		id := newConversationID()
-		require.NoError(t, mods.db.Save(id, "message 1", "gpt-4"))
+		require.NoError(t, mods.db.Save(id, "message 1", "openai", "gpt-4"))
 		mods.Config.Continue = "message 2"
 		mods.Config.Prefix = "prompt"
 		msg := mods.findCacheOpsDetails()()
@@ -122,7 +122,7 @@ func TestFindCacheOpsDetails(t *testing.T) {
 	t.Run("continue id and write with title", func(t *testing.T) {
 		mods := newMods(t)
 		id := newConversationID()
-		require.NoError(t, mods.db.Save(id, "message 1", "gpt-4"))
+		require.NoError(t, mods.db.Save(id, "message 1", "openai", "gpt-4"))
 		mods.Config.Title = "some title"
 		mods.Config.Continue = id[:10]
 		msg := mods.findCacheOpsDetails()()
@@ -137,7 +137,7 @@ func TestFindCacheOpsDetails(t *testing.T) {
 	t.Run("continue title and write with title", func(t *testing.T) {
 		mods := newMods(t)
 		id := newConversationID()
-		require.NoError(t, mods.db.Save(id, "message 1", "gpt-4"))
+		require.NoError(t, mods.db.Save(id, "message 1", "openai", "gpt-4"))
 		mods.Config.Title = "some title"
 		mods.Config.Continue = "message 1"
 		msg := mods.findCacheOpsDetails()()


### PR DESCRIPTION
- `default-api` in the configuration file
- cache stores the API as well - and displays it in the list
- improved resolution of api+model/aliases


this should give more control to which model/api to use

closes #300
