### PR TITLE
mod config_template.yml to remove api/ as it is already used in ollama api call

### DIFF
--- a/config_template.yml
+++ b/config_template.yml
@@ -204,7 +204,7 @@ apis:
         max-input-chars: 4194304
 
   ollama:
-    base-url: http://localhost:11434/api
+    base-url: http://localhost:11434
     models: # https://ollama.com/library
       "llama3.2:3b":
         aliases: ["llama3.2"]


### PR DESCRIPTION
The Ollama API already add a /api.

### Describe your changes

### Related issue/discussion: #516 