### PR TITLE
fix: Ensure that -m|--model selects the specified model

### DIFF
--- a/main.go
+++ b/main.go
@@ -795,10 +795,9 @@ func askInfo() error {
 		}
 	}
 
-	// wrapping is done by the caller
-	//nolint:wrapcheck
-	return huh.NewForm(
-		huh.NewGroup(
+	groups := make([]*huh.Group, 0, 2)
+	if config.AskModel {
+		groups = append(groups, huh.NewGroup(
 			huh.NewSelect[string]().
 				Title("Choose the API:").
 				Options(apis...).
@@ -811,21 +810,22 @@ func askInfo() error {
 					return opts[config.API]
 				}, &config.API).
 				Value(&config.Model),
-		).WithHideFunc(func() bool {
-			return !config.AskModel
-		}),
-		huh.NewGroup(
+		))
+	}
+
+	if config.Prefix == "" {
+		groups = append(groups, huh.NewGroup(
 			huh.NewText().
 				TitleFunc(func() string {
 					return fmt.Sprintf("Enter a prompt for %s:", config.Model)
 				}, &config.Model).
 				Value(&config.Prefix),
-		).WithHideFunc(func() bool {
-			return config.Prefix != ""
-		}),
-	).
-		WithTheme(themeFrom(config.Theme)).
-		Run()
+		))
+	}
+
+	// wrapping is done by the caller
+	//nolint:wrapcheck
+	return huh.NewForm(groups...).WithTheme(themeFrom(config.Theme)).Run()
 }
 
 //nolint:mnd


### PR DESCRIPTION
Just started using mods, loving it so far. Thank you for making it!

I noticed that specifying `-m`/`--model` does not choose the correct model - it chooses a random model. It seems that this is because of how the corresponding `huh.Form`'s `huh.Select`s are created.

Here's an example, using [this mods.yml](https://gist.github.com/mway/2ff0abdfb47133aeac30ea8daaa62224):

On `main`:
```
# go run . -m qwen3 --prompt-args
┃ Enter a prompt for mistral-saba-24b:

# go run . -m qwen3 --prompt-args
┃ Enter a prompt for deepseek-r1-distill-llama-70b:

# go run . -m qwen3 --prompt-args
┃ Enter a prompt for compound-beta-mini:
```

After this change:
```
# go run . -m qwen3 --prompt-args
┃ Enter a prompt for qwen3:

# go run . -m qwen3 --prompt-args
┃ Enter a prompt for qwen3:

# go run . -m qwen3 --prompt-args
┃ Enter a prompt for qwen3:
```

One thing I considered doing (without necessarily doing a larger refactor) was also passing `*Mods` to `askInfo`, so that it could call `Mods.resolveModel` in order to normalize (and validate) the model name/alias; otherwise, this is possible:

```
# go run . -m this-model-does-not-exist --prompt-args
┃ Enter a prompt for this-model-does-not-exist:
```

but that feels like a secondary cosmetic/ergonomic consideration compared to getting it to select the right model in the first place. If that's interesting to you I'll submit another PR with that change as well.