### PR TITLE
fix: show model picker if -m doesn't yield a valid model

### DIFF
--- a/main.go
+++ b/main.go
@@ -786,7 +786,7 @@ func askInfo() error {
 		for name, model := range api.Models {
 			opts[api.Name] = append(opts[api.Name], huh.NewOption(name, name))
 
-			// checks if the this is the model we intend to use if not using
+			// checks if this is the model we intend to use if not using
 			// `--ask-model`:
 			if !config.AskModel &&
 				(config.API == "" || config.API == api.Name) &&


### PR DESCRIPTION
this is an alternative to #539

basically, if the user runs `mods --ask-model`, it works like before.

if they run `mods -m <some model>`, without any extra input, it triggers the `askInfo` huh form, like before.

But now, it'll check before hand if mods yields a valid model. If not, it'll show the form to pick the model as well.

This should prevent issues like, when you have no `default-api` set, pass no `--api` flag, but have either `default-model` or pass a `--model`, and that model doesn't exist in the specified API.

