### PR TITLE
fix: improve mcp timeout handling

### DIFF
--- a/config.go
+++ b/config.go
@@ -74,6 +74,7 @@ var help = map[string]string{
 	"mcp-disable":       "Disable specific MCP servers",
 	"mcp-list":          "List all available MCP servers",
 	"mcp-list-tools":    "List all available tools from enabled MCP servers",
+	"mcp-timeout":       "Timeout for MCP server calls, defaults to 15 seconds",
 }
 
 // Model represents the LLM model used in the API call.
@@ -118,7 +119,7 @@ func (apis *APIs) UnmarshalYAML(node *yaml.Node) error {
 type FormatText map[string]string
 
 // UnmarshalYAML conforms with yaml.Unmarshaler.
-func (ft *FormatText) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (ft *FormatText) UnmarshalYAML(unmarshal func(any) error) error {
 	var text string
 	if err := unmarshal(&text); err != nil {
 		var formats map[string]string
@@ -189,6 +190,7 @@ type Config struct {
 	MCPList      bool
 	MCPListTools bool
 	MCPDisable   []string
+	MCPTimeout   time.Duration `yaml:"mcp-timeout" env:"MCP_TIMEOUT"`
 
 	openEditor                                         bool
 	cacheReadFromID, cacheWriteToID, cacheWriteToTitle string
@@ -282,6 +284,7 @@ func defaultConfig() Config {
 			"markdown": defaultMarkdownFormatText,
 			"json":     defaultJSONFormatText,
 		},
+		MCPTimeout: 15 * time.Second,
 	}
 }
 

--- a/config_template.yml
+++ b/config_template.yml
@@ -20,6 +20,8 @@ mcp-servers:
   #     - "-e"
   #     - GITHUB_PERSONAL_ACCESS_TOKEN
   #     - "ghcr.io/github/github-mcp-server"
+# {{ index .Help "mcp-timeout" }}
+mcp-timeout: 15s
 # {{ index .Help "roles" }}
 roles:
   "default": []


### PR DESCRIPTION
This pull request introduces a configurable timeout for MCP server calls, refactors context handling to improve cancellation and concurrency, and updates type usage for better code consistency. The most significant changes are grouped into three themes: MCP timeout configuration, context and concurrency improvements, and type updates.

### MCP Timeout Configuration:
* Added a new `MCPTimeout` field to the `Config` struct with a default value of 15 seconds. This timeout is configurable via YAML and environment variables (`yaml:"mcp-timeout" env:"MCP_TIMEOUT"`) [[1]](diffhunk://#diff-0e426a43248661127a0c0ee115aef7a1093b635f8993b3f7ebb1dd9f05b8f249R193) [[2]](diffhunk://#diff-0e426a43248661127a0c0ee115aef7a1093b635f8993b3f7ebb1dd9f05b8f249R287) [[3]](diffhunk://#diff-4d3271dfec3558167d9e0aa882e82e40a412465b4e9eee71dbe74a794b0d30eaR23-R24).
* Updated the `help` map to include a description for the `mcp-timeout` option.
* Integrated the `MCPTimeout` value into context creation for MCP server calls, replacing hardcoded timeouts [[1]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L209-R208) [[2]](diffhunk://#diff-d92d2fa2f22fc443e1ae12da3fc2e8556aa5e643eb96c0f72c013ea3b43495e5L400-R414) [[3]](diffhunk://#diff-d92d2fa2f22fc443e1ae12da3fc2e8556aa5e643eb96c0f72c013ea3b43495e5L424-R433).

### Context and Concurrency Improvements:
* Refactored the `Mods` struct to manage multiple cancel functions (`cancelRequest` changed from a single `context.CancelFunc` to a slice) and added a shared context field (`ctx`) for centralized context management [[1]](diffhunk://#diff-d92d2fa2f22fc443e1ae12da3fc2e8556aa5e643eb96c0f72c013ea3b43495e5L66-R66) [[2]](diffhunk://#diff-d92d2fa2f22fc443e1ae12da3fc2e8556aa5e643eb96c0f72c013ea3b43495e5R77-R87) [[3]](diffhunk://#diff-d92d2fa2f22fc443e1ae12da3fc2e8556aa5e643eb96c0f72c013ea3b43495e5R104).
* Improved concurrency in MCP tool listing by using `errgroup.Group` for parallel execution and a mutex to safely update shared data.
* Enhanced error handling for MCP tool listing, including specific handling for context deadline exceeded errors.

### Type Updates:
* Replaced the `interface{}` type with `any` in YAML unmarshaling and error handling for improved readability and modern Go practices [[1]](diffhunk://#diff-0e426a43248661127a0c0ee115aef7a1093b635f8993b3f7ebb1dd9f05b8f249L121-R122) [[2]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L446-R454) [[3]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L463-R466) [[4]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L473-R476).

These changes collectively enhance the configurability, robustness, and maintainability of the codebase.