### PR TITLE
fix: mkdir parent db directory

### DIFF
--- a/config.go
+++ b/config.go
@@ -233,7 +233,10 @@ func ensureConfig() (Config, error) {
 		c.CachePath = filepath.Join(xdg.DataHome, "mods")
 	}
 
-	if err := os.MkdirAll(c.CachePath, 0o700); err != nil { //nolint:mnd
+	if err := os.MkdirAll(
+		filepath.Join(c.CachePath, "conversations"),
+		0o700,
+	); err != nil { //nolint:mnd
 		return c, modsError{err, "Could not create cache directory."}
 	}
 

--- a/main.go
+++ b/main.go
@@ -140,13 +140,13 @@ var (
 						fmt.Println(filepath.Dir(config.SettingsPath))
 						return nil
 					case "cache":
-						fmt.Println(filepath.Dir(config.CachePath))
+						fmt.Println(config.CachePath)
 						return nil
 					}
 				}
 				fmt.Printf("Configuration: %s\n", filepath.Dir(config.SettingsPath))
 				//nolint:mnd
-				fmt.Printf("%*sCache: %s\n", 8, " ", filepath.Dir(config.CachePath))
+				fmt.Printf("%*sCache: %s\n", 8, " ", config.CachePath)
 				return nil
 			}
 
@@ -347,12 +347,7 @@ func main() {
 	initFlags()
 
 	if !isCompletionCmd(os.Args) && !isManCmd(os.Args) && !isVersionOrHelpCmd(os.Args) {
-		ds := filepath.Join(config.CachePath, "conversations", "mods.db")
-		if err := os.MkdirAll(filepath.Dir(ds), 0o700); err != nil {
-			handleError(modsError{err, "Could not open database."})
-			os.Exit(1)
-		}
-		db, err = openDB(ds)
+		db, err = openDB(filepath.Join(config.CachePath, "conversations", "mods.db"))
 		if err != nil {
 			handleError(modsError{err, "Could not open database."})
 			os.Exit(1)

--- a/main.go
+++ b/main.go
@@ -347,7 +347,12 @@ func main() {
 	initFlags()
 
 	if !isCompletionCmd(os.Args) && !isManCmd(os.Args) && !isVersionOrHelpCmd(os.Args) {
-		db, err = openDB(filepath.Join(config.CachePath, "conversations", "mods.db"))
+		ds := filepath.Join(config.CachePath, "conversations", "mods.db")
+		if err := os.MkdirAll(filepath.Dir(ds), 0o700); err != nil {
+			handleError(modsError{err, "Could not open database."})
+			os.Exit(1)
+		}
+		db, err = openDB(ds)
 		if err != nil {
 			handleError(modsError{err, "Could not open database."})
 			os.Exit(1)


### PR DESCRIPTION
closes #549

make sure the `CACHE/conversations` dir is created as well