### PR TITLE
refactor: rename MCP configuration flags for clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,9 +165,9 @@ Check the [`./features.md`](./features.md) for more details.
 
 #### MCP
 
+- `--mcp-enable`: Enable specific MCP servers (MCPs are disabled by default)
 - `--mcp-list`: List all available MCP servers
 - `--mcp-list-tools`: List all available tools from enabled MCP servers
-- `--mcp-disable`: Disable specific MCP servers
 
 #### Advanced
 

--- a/config.go
+++ b/config.go
@@ -71,7 +71,7 @@ var help = map[string]string{
 	"show-last":         "Show the last saved conversation",
 	"editor":            "Edit the prompt in your $EDITOR; only taken into account if no other args and if STDIN is a TTY",
 	"mcp-servers":       "MCP Servers configurations",
-	"mcp-disable":       "Disable specific MCP servers",
+	"mcp-enable":        "Enable specific MCP servers (MCPs are disabled by default)",
 	"mcp-list":          "List all available MCP servers",
 	"mcp-list-tools":    "List all available tools from enabled MCP servers",
 	"mcp-timeout":       "Timeout for MCP server calls, defaults to 15 seconds",
@@ -189,7 +189,7 @@ type Config struct {
 	MCPServers   map[string]MCPServerConfig `yaml:"mcp-servers"`
 	MCPList      bool
 	MCPListTools bool
-	MCPDisable   []string
+	MCPEnable    []string
 	MCPTimeout   time.Duration `yaml:"mcp-timeout" env:"MCP_TIMEOUT"`
 
 	openEditor                                         bool

--- a/main.go
+++ b/main.go
@@ -285,7 +285,7 @@ func initFlags() {
 	flags.BoolVarP(&config.openEditor, "editor", "e", false, stdoutStyles().FlagDesc.Render(help["editor"]))
 	flags.BoolVar(&config.MCPList, "mcp-list", false, stdoutStyles().FlagDesc.Render(help["mcp-list"]))
 	flags.BoolVar(&config.MCPListTools, "mcp-list-tools", false, stdoutStyles().FlagDesc.Render(help["mcp-list-tools"]))
-	flags.StringArrayVar(&config.MCPDisable, "mcp-disable", nil, stdoutStyles().FlagDesc.Render(help["mcp-disable"]))
+	flags.StringArrayVar(&config.MCPEnable, "mcp-enable", nil, stdoutStyles().FlagDesc.Render(help["mcp-enable"]))
 	flags.Lookup("prompt").NoOptDefVal = "-1"
 	flags.SortFlags = false
 

--- a/mcp.go
+++ b/mcp.go
@@ -33,8 +33,13 @@ func enabledMCPs() iter.Seq2[string, MCPServerConfig] {
 }
 
 func isMCPEnabled(name string) bool {
-	return !slices.Contains(config.MCPDisable, "*") &&
-		!slices.Contains(config.MCPDisable, name)
+	// If MCPEnable is empty, no MCPs are enabled (disabled by default)
+	if len(config.MCPEnable) == 0 {
+		return false
+	}
+
+	// Check if this specific server is enabled
+	return slices.Contains(config.MCPEnable, name) || slices.Contains(config.MCPEnable, "*")
 }
 
 func mcpList() {
@@ -42,6 +47,8 @@ func mcpList() {
 		s := name
 		if isMCPEnabled(name) {
 			s += stdoutStyles().Timeago.Render(" (enabled)")
+		} else {
+			s += stdoutStyles().Comment.Render(" (disabled)")
 		}
 		fmt.Println(s)
 	}


### PR DESCRIPTION
- Changed `mcp-disable` to `mcp-enable` to reflect that MCPs are disabled by default.
- Updated related documentation and help messages to align with the new flag naming.
- Adjusted logic in the MCP handling to check for enabled servers based on the new configuration.


### Related issue/discussion: #570 

### Checklist before requesting a review

- [ ] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md)
- [ ] I have performed a self-review of my code

### If this is a feature

- [ ] I have created a discussion
- [ ] A project maintainer has approved this feature request. Link to comment:
