### PR TITLE
Update readFromCache to handle raw mode

### DIFF
--- a/mods.go
+++ b/mods.go
@@ -636,7 +636,19 @@ func (m *Mods) readFromCache() tea.Cmd {
 			return modsError{err, "There was an error loading the conversation."}
 		}
 
-		m.appendToOutput(proto.Conversation(messages).String())
+		content := proto.Conversation(messages).String()
+
+		// In raw mode, directly print the content instead of using glamour
+		if m.Config.Raw {
+			fmt.Print(content)
+			return completionOutput{
+				errh: func(err error) tea.Msg {
+					return modsError{err: err}
+				},
+			}
+		}
+
+		m.appendToOutput(content)
 		return completionOutput{
 			errh: func(err error) tea.Msg {
 				return modsError{err: err}


### PR DESCRIPTION
- Add raw mode handling to readFromCache that directly prints content without glamour formatting
- Return early with completionOutput in raw mode instead of appending to output
- Add test to verify raw mode doesn't panic and returns expected message type
