### PR TITLE
fix: mods -s should print even when no tty attached

### DIFF
--- a/main.go
+++ b/main.go
@@ -219,12 +219,23 @@ var (
 			}
 
 			// raw mode already prints the output, no need to print it again
-			if isOutputTTY() && !config.Raw {
-				switch {
-				case mods.glamOutput != "":
-					fmt.Print(mods.glamOutput)
-				case mods.Output != "":
-					fmt.Print(mods.Output)
+			// When stdout is a TTY, we render to stderr during run and mirror the
+			// final output to stdout here. When stdout is not a TTY, streaming
+			// already prints to stdout except for --show/--show-last which do not
+			// stream; in that case, print the captured output here.
+			if !config.Raw {
+				if isOutputTTY() {
+					switch {
+					case mods.glamOutput != "":
+						fmt.Print(mods.glamOutput)
+					case mods.Output != "":
+						fmt.Print(mods.Output)
+					}
+				} else if config.Show != "" || config.ShowLast {
+					// Non-TTY: ensure --show/--show-last prints when redirected/piped
+					if mods.Output != "" {
+						fmt.Print(mods.Output)
+					}
 				}
 			}
 


### PR DESCRIPTION
### Describe your changes

Print output even when no tty output attached. Code generated by codex gpt-5, but the generated code does seem to make sense and work.

### Related issue/discussion: https://github.com/charmbracelet/mods/issues/602

### Checklist before requesting a review

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my code

### If this is a feature

- [ ] I have created a discussion
- [ ] A project maintainer has approved this feature request. Link to comment:
