### PR TITLE
feat: Allow Azure AD API version to be configured

### DIFF
--- a/config.go
+++ b/config.go
@@ -93,7 +93,7 @@ type API struct {
 	APIKey    string           `yaml:"api-key"`
 	APIKeyEnv string           `yaml:"api-key-env"`
 	APIKeyCmd string           `yaml:"api-key-cmd"`
-	Version   string           `yaml:"version"` // XXX: not used anywhere
+	Version   string           `yaml:"version"` // Used by azure-ad
 	BaseURL   string           `yaml:"base-url"`
 	Models    map[string]Model `yaml:"models"`
 	User      string           `yaml:"user"`

--- a/internal/openai/openai.go
+++ b/internal/openai/openai.go
@@ -30,6 +30,15 @@ type Config struct {
 		Do(*http.Request) (*http.Response, error)
 	}
 	APIType string
+	Version string
+}
+
+// getVersion returns the API version to be used for azure-ad.
+func (c Config) getVersion() string {
+	if c.Version != "" {
+		return c.Version
+	}
+	return "v1"
 }
 
 // DefaultConfig returns the default configuration for the OpenAI API client.
@@ -50,7 +59,7 @@ func New(config Config) *Client {
 	if config.APIType == "azure-ad" {
 		opts = append(opts, azure.WithAPIKey(config.AuthToken))
 		if config.BaseURL != "" {
-			opts = append(opts, azure.WithEndpoint(config.BaseURL, "v1"))
+			opts = append(opts, azure.WithEndpoint(config.BaseURL, config.getVersion()))
 		}
 	} else {
 		opts = append(opts, option.WithAPIKey(config.AuthToken))

--- a/mods.go
+++ b/mods.go
@@ -353,6 +353,7 @@ func (m *Mods) startCompletionCmd(content string) tea.Cmd {
 			}
 			if mod.API == "azure-ad" {
 				ccfg.APIType = "azure-ad"
+				ccfg.Version = api.Version
 			}
 			if api.User != "" {
 				cfg.User = api.User


### PR DESCRIPTION
This is a pretty simple feature to allow the API version to be configured when using Azure AD (`mods` is unusable otherwise in some cases).

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).
