### PR TITLE
Update config_template.yml with current OpenAI models

### DIFF
--- a/config_template.yml
+++ b/config_template.yml
@@ -75,17 +75,27 @@ apis:
     api-key-env: OPENAI_API_KEY
     # api-key-cmd: rbw get -f OPENAI_API_KEY chat.openai.com
     models: # https://platform.openai.com/docs/models
-      gpt-4.5-preview: #128k https://platform.openai.com/docs/models/gpt-4.5-preview
-        aliases: ["gpt-4.5", "gpt4.5"]
-        max-input-chars: 392000
-        fallback: gpt-4
-      gpt-4.5-preview-2025-02-27:
-        max-input-chars: 392000
-        fallback: gpt-4
       gpt-4o-mini:
         aliases: ["4o-mini"]
         max-input-chars: 392000
         fallback: gpt-4o
+      # GPT-5 Series (Current Flagship)
+      gpt-5:
+        aliases: ["5", "gpt5", "gpt-5-thinking", "gpt5-thinking"]
+        max-input-chars: 794000
+        fallback: gpt-4o
+      gpt-5-mini:
+        aliases: ["5mini", "gpt5mini"]
+        max-input-chars: 400000
+        fallback: gpt-5
+      gpt-5-nano:
+        aliases: ["5nano", "gpt5nano"]
+        max-input-chars: 200000
+        fallback: gpt-5-mini
+      gpt-5-codex:
+        aliases: ["5codex", "gpt5codex", "codex"]
+        max-input-chars: 400000
+        fallback: gpt-5
       gpt-4o:
         aliases: ["4o"]
         max-input-chars: 392000
@@ -127,9 +137,19 @@ apis:
       o1-mini:
         aliases: ["o1-mini"]
         max-input-chars: 128000
+      # O3 Series (Advanced Reasoning Models)
+      o3:
+        aliases: ["o3"]
+        max-input-chars: 794000
+        fallback: o3-mini
+      o3-pro:
+        aliases: ["o3-pro", "o3pro"]
+        max-input-chars: 794000
+        fallback: o3
       o3-mini:
         aliases: ["o3m", "o3-mini"]
         max-input-chars: 200000
+        fallback: o1-mini
   copilot:
     base-url: https://api.githubcopilot.com
     models:


### PR DESCRIPTION
AI Assistant:

## Summary

This PR updates `config_template.yml` to reflect the current OpenAI model lineup by:

* Removing non-existent gpt-4.5 models
* Adding GPT-5 family models (current flagship generation)
* Adding O3 reasoning models (o3, o3-pro)
* Improving fallback chains for graceful degradation

## Changes

### Removed

* `gpt-4.5-preview` - This model does not exist in OpenAI's API
* `gpt-4.5-preview-2025-02-27` - This model does not exist in OpenAI's API

### Added - GPT-5 Family

* `gpt-5` - Flagship model with reasoning capabilities
  * Aliases: `5`, `gpt5`, `gpt-5-thinking`, `gpt5-thinking`
  * Max input: 794k chars
  * Fallback: gpt-4o
* `gpt-5-mini` - Cost-optimized GPT-5 variant
  * Aliases: `5mini`, `gpt5mini`
  * Max input: 400k chars
  * Fallback: gpt-5
* `gpt-5-nano` - High-throughput variant
  * Aliases: `5nano`, `gpt5nano`
  * Max input: 200k chars
  * Fallback: gpt-5-mini
* `gpt-5-codex` - Specialized coding model
  * Aliases: `5codex`, `gpt5codex`, `codex`
  * Max input: 400k chars
  * Fallback: gpt-5

### Added - O3 Reasoning Models

* `o3` - Advanced reasoning model
  * Aliases: `o3`
  * Max input: 794k chars
  * Fallback: o3-mini
* `o3-pro` - Most capable reasoning model
  * Aliases: `o3-pro`, `o3pro`
  * Max input: 794k chars
  * Fallback: o3

### Updated

* `o3-mini` - Added fallback chain: `o1-mini`

## Test Plan

* Verified model names against [OpenAI Platform documentation](https://platform.openai.com/docs/models)
* Validated YAML syntax
* Checked aliases don't conflict with existing models
* Ensured fallback chains are logical and available

## Documentation

Models documented:

* [GPT-5](https://platform.openai.com/docs/models/gpt-5)
* [O3 Models](https://platform.openai.com/docs/models/o3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)