### PR TITLE
fix: fix perplexity API

### DIFF
--- a/config_template.yml
+++ b/config_template.yml
@@ -240,22 +240,21 @@ apis:
     models: # https://docs.perplexity.ai/getting-started/models
       # search models
       sonar:
-        aliases: ["sonar"]
         max-input-chars: 127072
       sonar-pro:
-        aliases: ["sonar-pro"]
         max-input-chars: 127072
+        fallback: sonar
       # reasoning models
       sonar-reasoning:
-        aliases: ["sonar-reasoning"]
         max-input-chars: 127072
+        fallback: sonar
       sonar-reasoning-pro:
-        aliases: ["sonar-reasoning-pro"]
         max-input-chars: 127072
+        fallback: sonar
       # research models
       sonar-deep-research:
-        aliases: ["sonar-deep-research"]
         max-input-chars: 127072
+        fallback: sonar
 
   groq:
     base-url: https://api.groq.com/openai/v1


### PR DESCRIPTION
The perplexity API models are not available anymore and return 400 API errors. I replaced the models in the settings template file with the current ones available according to the official docs at: https://docs.perplexity.ai/getting-started/models
<img width="1906" height="131" alt="image" src="https://github.com/user-attachments/assets/0c52ba43-bcff-418e-94ca-c62ec2a5e693" />

### Steps to reproduce
1. Type `mods --settings` in the terminal and ENTER
2. Add a Perplexity API key.
3. Change the default model to any Perplexity model.
4. Try to use mods. `mods 'Hey, are you doing?'`
5. Get an error 400 API, model does not exist.


- [X] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [X] I have created a discussion that was approved by a maintainer (for new features). <- Not necessary, since this is a bug fix, not a new feature.
