### PR TITLE
Added --rename flag to rename conversations

### DIFF
--- a/config.go
+++ b/config.go
@@ -66,6 +66,7 @@ var help = map[string]string{
 	"list":              "Lists saved conversations",
 	"delete":            "Deletes one or more saved conversations with the given titles or IDs",
 	"delete-older-than": "Deletes all saved conversations older than the specified duration; valid values are " + strings.EnglishJoin(duration.ValidUnits(), true),
+	"rename":            "Renames saved conversations.",
 	"show":              "Show a saved conversation with the given title or ID",
 	"theme":             "Theme to use in the forms; valid choices are charm, catppuccin, dracula, and base16",
 	"show-last":         "Show the last saved conversation",
@@ -184,6 +185,7 @@ type Config struct {
 	ListRoles           bool
 	Delete              []string
 	DeleteOlderThan     time.Duration
+	Rename              []string
 	User                string
 
 	MCPServers   map[string]MCPServerConfig `yaml:"mcp-servers"`

--- a/main.go
+++ b/main.go
@@ -215,7 +215,6 @@ var (
 			}
 
 			if len(config.Delete) > 0 {
-				fmt.Fprintln(os.Stdout, config.Delete)
 				return deleteConversations()
 			}
 

--- a/mods.go
+++ b/mods.go
@@ -149,6 +149,7 @@ func (m *Mods) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		if m.Config.Dirs ||
 			len(m.Config.Delete) > 0 ||
+			len(m.Config.Rename) > 0 ||
 			m.Config.DeleteOlderThan != 0 ||
 			m.Config.ShowHelp ||
 			m.Config.List ||


### PR DESCRIPTION
Added the --rename flag to rename conversations, based on https://github.com/charmbracelet/mods/issues/477


Currently the default title is the first user prompt that the user provides. this isn't sufficient enough to track which chatrooms had what content.
the issue also asked for default title to be an AI generated one, this PR does not implement AI-generated titles, but provides a manual renaming option through `--rename`.


Changes Made
- Introduced `--rename` CLI flag.  
- Added logic to update stored conversation metadata with new titles.  
- Updated help text to reflect the new option.  

Demo
<img src="https://github.com/user-attachments/assets/2e08fa87-f0ef-45bf-b85a-63840b9a5a5d" alt="rename-feat" width="400">

Tests
<img src="https://github.com/user-attachments/assets/d387afa8-b022-496d-a129-e9101c537e5d" alt="tests-passed" width="350">

