### PR TITLE
Added support for gemini 2.5

### DIFF
--- a/config_template.yml
+++ b/config_template.yml
@@ -178,18 +178,15 @@ apis:
         max-input-chars: 128000
   google:
     models: # https://ai.google.dev/gemini-api/docs/models/gemini
-      gemini-1.5-pro-latest:
-        aliases: ["gmp", "gemini", "gemini-1.5-pro"]
+      gemini-2.5-pro:
+        aliases: ["gemini", "gemini-2.5-pro"]
         max-input-chars: 392000
-      gemini-1.5-flash-latest:
-        aliases: ["gmf", "flash", "gemini-1.5-flash"]
+      gemini-2.5-flash:
+        aliases: ["flash", "gemini-2.5-flash"]
         max-input-chars: 392000
-      gemini-2.0-flash-001:
-        aliases: ["gm2f", "flash-2", "gemini-2-flash"]
-        max-input-chars: 4194304
-      gemini-2.0-flash-lite:
-        aliases: ["gm2fl", "flash-2-lite", "gemini-2-flash-lite"]
-        max-input-chars: 4194304
+      gemini-flash-lite-latest:
+        aliases: ["flash-lite", "gemini-flash-lite"]
+        max-input-chars: 392000
 
   ollama:
     base-url: http://localhost:11434

--- a/internal/google/google.go
+++ b/internal/google/google.go
@@ -16,6 +16,8 @@ import (
 	"github.com/openai/openai-go"
 )
 
+var gemini_global_messages = []proto.Message{{proto.RoleUser, "Default Gemini Message", []proto.ToolCall{}}}
+
 var _ stream.Client = &Client{}
 
 const emptyMessagesLimit uint = 300
@@ -105,6 +107,7 @@ func (c *Client) Request(ctx context.Context, request proto.Request) stream.Stre
 			MaxOutputTokens:  4096,
 		},
 	}
+	gemini_global_messages = append(gemini_global_messages, request.Messages...)
 
 	if request.Temperature != nil {
 		body.GenerationConfig.Temperature = *request.Temperature
@@ -213,7 +216,7 @@ func (s *Stream) Err() error { return s.err }
 // Messages implements stream.Stream.
 func (s *Stream) Messages() []proto.Message {
 	// Gemini does not support returning streamed messages after the fact.
-	return nil
+	return gemini_global_messages
 }
 
 // Next implements stream.Stream.


### PR DESCRIPTION
This PR removes the old gemini models and adds the latest 2.5 variants.
Additionally, this also fixes a gemini-specific bug related to generating conversation title, preventing the conversations from being saved (unless the title was explicitly supplied by the `-t` switch).

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
