### PR TITLE
fix(ollama): prevent infinite loop in stream responses

### DIFF
--- a/internal/ollama/ollama.go
+++ b/internal/ollama/ollama.go
@@ -64,7 +64,7 @@ func (c *Client) Request(ctx context.Context, request proto.Request) stream.Stre
 		body.Options["stop"] = request.Stop[0]
 	}
 	if request.MaxTokens != nil {
-		body.Options["num_ctx"] = *request.MaxTokens
+		body.Options["num_predict"] = *request.MaxTokens
 	}
 	if request.Temperature != nil {
 		body.Options["temperature"] = *request.Temperature
@@ -159,6 +159,10 @@ func (s *Stream) Next() bool {
 		return false
 	}
 	if s.done {
+		// Only restart if there are tool calls to process
+		if len(s.message.ToolCalls) == 0 {
+			return false
+		}
 		s.done = false
 		s.factory()
 		s.messages = append(s.messages, toProtoMessage(s.message))


### PR DESCRIPTION
fix(ollama): prevent infinite loop in stream responses without tool calls

    Fix two issues in the Ollama client:

    1. Change MaxTokens mapping from num_ctx to num_predict
       - num_ctx is the context window size
       - num_predict is the max tokens to generate (correct parameter)

    2. Prevent infinite loop in Next() method
       - Previously, Next() would restart the stream when done, even without tool calls
       - Now only restarts if there are actual tool calls to process
       - Fixes issue where simple queries would repeat indefinitely

    Tested with local Ollama instance (mistral:latest, mixtral:latest, deepseek-coder:latest)
    and confirmed responses now complete correctly without repetition.

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [x] I have created a discussion that was approved by a maintainer (for new features).
